### PR TITLE
v3.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,15 +74,22 @@ When adding or editing a README example, update the matching test in the same ch
 
 Non-README tests (sentinel-identity checks, internal plumbing) live in separately-named spec files (e.g. `v3.spec.ts`, `machine.spec.ts`), keeping the `examples.spec.ts` files purely doc-driven.
 
-## Relationship to `@turing-machine-js/machine` v3.0.0
+## Relationship to `@turing-machine-js/machine` v3.0.x
 
-The peer dependency is `^3.0.0`. The v3 upstream brought one breaking change and a batch of additive utilities; this package was made compatible with v3 in 3.0.0 of itself.
+The peer dependency is `^3.0.1`. The v3 upstream brought one breaking change and a batch of additive utilities; this package was made compatible with v3 in 3.0.0 of itself, and gained Post-aware wrappers + a direct `MachineState` import in 3.0.1.
 
-- **Breaking (upstream):** the `./src` subpath in `@turing-machine-js/machine`'s `exports` was removed. post-machine-js was never affected — all imports use the bare specifier `'@turing-machine-js/machine'`.
-- **Additive (upstream):** `State.toGraph` / `State.fromGraph` / `State.inspect`, Mermaid round-trip via `toMermaid` / `fromMermaid`, `summarize` / `summarizeGraph`, and `equivalentOn`. v3 of `@post-machine-js/machine` re-exports the function-style entry points (`State`, `toMermaid`, `fromMermaid`, `summarize`, `summarizeGraph`, `equivalentOn`) and their types so consumers don't need to import the upstream package separately. `PostMachine` also gained one — and only one — new instance member:
+- **Breaking (upstream, v3.0.0):** the `./src` subpath in `@turing-machine-js/machine`'s `exports` was removed. post-machine-js was never affected — all imports use the bare specifier `'@turing-machine-js/machine'`.
+- **Additive (upstream, v3.0.0):** `State.toGraph` / `State.fromGraph` / `State.inspect`, Mermaid round-trip via `toMermaid` / `fromMermaid`, `summarize` / `summarizeGraph`, and `equivalentOn`. post 3.0.0 re-exports the function-style entry points (`State`, `toMermaid`, `fromMermaid`, `summarize`, `summarizeGraph`, `equivalentOn`) and their types so consumers don't need to import the upstream package separately.
+- **PostMachine instance surface (added in post 3.0.0):** one — and only one — new instance member:
   - `machine.initialState` — getter exposing the precomputed start state. Required for the upstream utilities to act on a PostMachine.
 
-  No v3 utility is exposed as a PostMachine method. They're all called as bare functions against `machine.initialState` and `machine.tapeBlock`: `State.toGraph(machine.initialState, machine.tapeBlock)`, `toMermaid(State.toGraph(...))`, `summarize(machine.initialState, machine.tapeBlock)`, `equivalentOn({ state, getTapeBlock }, ..., cases)`. This is principled, not arbitrary — keeping one way to invoke each utility avoids ambiguity for users (no "do I use `machine.toMermaid()` or `toMermaid(...)`?") and avoids the awkward question of "why does `toMermaid` get a method but `summarize` doesn't?"
+  No v3 utility is exposed as a PostMachine method. The reason — keeping one way to invoke each utility avoids ambiguity (no "do I use `machine.toMermaid()` or `toMermaid(...)`?") and avoids the awkward question of "why does `toMermaid` get a method but `summarize` doesn't?"
+- **Post-aware wrappers (added in post 3.0.1):** two free-function wrappers around the most-used upstream utilities:
+  - `summarizePostMachine(machine)` — sugar for `summarize(machine.initialState, machine.tapeBlock)`.
+  - `equivalentPostMachines(reference, candidate, cases, options?)` — sugar for `equivalentOn` against two PostMachines, hiding the `getTapeBlock` clone-the-originating-block footgun. Pass-through `options` arg is forwarded to upstream.
+
+  These coexist with the bare upstream re-exports — wrappers are the recommended path for typical usage; the bare functions remain available for advanced cases (e.g., comparing a PostMachine against a hand-rolled TuringMachine via `equivalentOn`).
+- **`MachineState` direct import (post 3.0.1, requires turing 3.0.1+):** turing 3.0.1 added `MachineState` to its `index.ts` re-exports. PostMachine.ts now imports it directly via `import { type MachineState } from '@turing-machine-js/machine'` instead of using the prior `Generator<infer T>` extraction workaround. The peer dep was bumped to `^3.0.1` to enforce typecheck against turing 3.0.1+.
 
 ### Jest moduleNameMapper points at `dist/index.cjs`, not `dist/index.js`
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.0",
+  "version": "3.0.1",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "@turing-machine-js/machine": "^3.0.1"
+      },
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.2",
@@ -4354,10 +4357,9 @@
       }
     },
     "node_modules/@turing-machine-js/machine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-3.0.0.tgz",
-      "integrity": "sha512-gOu4Y6pJZ2rIf0/7+v6Q8MMlZ64+uf3tG5ctiuHKvjh1RY3VpT7J/yv7nuTQS9f1qsbNluDxDLcFRHuu5Yr0pw==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-3.0.1.tgz",
+      "integrity": "sha512-Xs3MjO8oeWfI9ohG/zjygv/0xWCI7r2UrayOAdNX6X30LQ37LPteVdhNEqW35JpfOxs0VVhvoV8+xUS1pXZrqg==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -7214,7 +7216,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -13471,16 +13475,16 @@
     },
     "packages/machine": {
       "name": "@post-machine-js/machine",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
-        "@turing-machine-js/machine": "^3.0.0"
+        "@turing-machine-js/machine": "^3.0.1"
       },
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^3.0.0"
+        "@turing-machine-js/machine": "^3.0.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "rollup": "^4.60.2",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1"
+  },
+  "dependencies": {
+    "@turing-machine-js/machine": "^3.0.1"
   }
 }

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2026-04-30
+
+### Added
+
+- **`summarizePostMachine(machine)`** — Post-aware free-function wrapper for `summarize(machine.initialState, machine.tapeBlock)`. Saves the caller from passing the two args.
+- **`equivalentPostMachines(reference, candidate, cases, options?)`** — Post-aware wrapper for `equivalentOn` against two `PostMachine` instances. Hides the `getTapeBlock`-must-clone footgun (PostMachine state-graph symbols are interned per-block, so a fresh `TapeBlock.fromAlphabets([alphabet])` doesn't work — the wrapper passes `() => machine.tapeBlock.clone()` factories internally). Pass-through `options` arg is forwarded to upstream `equivalentOn`.
+
+### Changed (internal)
+
+- **`MachineState`** is now imported directly from `@turing-machine-js/machine` (re-exported from its `index.ts` in turing 3.0.1) instead of being extracted via `Generator<infer T>` from `runStepByStep`'s return signature. No observable change; cleaner code.
+- **`peerDependencies['@turing-machine-js/machine']`** raised from `^3.0.0` to `^3.0.1`. Required because the new direct `MachineState` import only typechecks against turing 3.0.1+. Runtime is unchanged (turing 3.0.1 is a patch — no breaking changes from 3.0.0).
+
 ## [3.0.0] - 2026-04-30
 
 ### Added

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -141,7 +141,7 @@ For a single subroutine called from MULTIPLE sites — the other archetypal use 
 
 ## Introspection and equivalence
 
-The v3 utilities from [`@turing-machine-js/machine`](https://github.com/mellonis/turing-machine-js/tree/master/packages/machine) work directly against a `PostMachine` — `machine.initialState` exposes the precomputed start state and `machine.tapeBlock` is inherited from `TuringMachine`. The utilities are re-exported here so the upstream package doesn't need to be imported separately. Call them as bare functions — `PostMachine` doesn't wrap them in methods (the bare-function form keeps a single way to do each thing).
+The v3 utilities from [`@turing-machine-js/machine`](https://github.com/mellonis/turing-machine-js/tree/master/packages/machine) work directly against a `PostMachine`. For the two most common ones — `summarize` and `equivalentOn` — this package also ships Post-aware free-function wrappers (`summarizePostMachine`, `equivalentPostMachines`) that bind the standard arguments and hide the `getTapeBlock`-must-clone footgun. **Prefer the wrappers for typical use.** The bare upstream functions are still re-exported here for advanced cases.
 
 ### Visualization — `toMermaid` + `State.toGraph`
 
@@ -161,14 +161,14 @@ console.log(mermaid.split('\n')[0]); // flowchart TD
 
 For the raw `Graph` as input to other tools, use `State.toGraph(machine.initialState, machine.tapeBlock)` directly.
 
-### Structural summary — `summarize`
+### Structural summary — `summarizePostMachine`
 
-`summarize(initialState, tapeBlock)` returns counts about the assembled state graph: `stateCount`, `transitionCount`, `compositionEdgeCount`, `maxCompositionDepth`, `selfLoopCount`, `hasCycles`, `tapeCount`, `alphabetCardinalities`. For a PostMachine, `tapeCount` is always `1` and `alphabetCardinalities` is always `[2]` (one tape, two symbols — blank and mark); the interesting fields are the rest.
+`summarizePostMachine(machine)` returns counts about the assembled state graph: `stateCount`, `transitionCount`, `compositionEdgeCount`, `maxCompositionDepth`, `selfLoopCount`, `hasCycles`, `tapeCount`, `alphabetCardinalities`. For a PostMachine, `tapeCount` is always `1` and `alphabetCardinalities` is always `[2]` (one tape, two symbols — blank and mark); the interesting fields are the rest.
 
 The typical use is comparing two implementations of the same algorithm — for example, an inline version against one factored through a subroutine:
 
 ```javascript
-import { PostMachine, summarize, call, check, mark, right, stop } from '@post-machine-js/machine';
+import { PostMachine, summarizePostMachine, call, check, mark, right, stop } from '@post-machine-js/machine';
 
 // Both machines walk right to the first blank cell and mark it.
 
@@ -190,8 +190,8 @@ const withSubroutine = new PostMachine({
   30: stop,
 });
 
-const a = summarize(inline.initialState, inline.tapeBlock);
-const b = summarize(withSubroutine.initialState, withSubroutine.tapeBlock);
+const a = summarizePostMachine(inline);
+const b = summarizePostMachine(withSubroutine);
 
 console.log(a.stateCount, a.compositionEdgeCount, a.maxCompositionDepth);
 // 4 0 0 — inline: 4 states, no composition
@@ -200,14 +200,16 @@ console.log(b.stateCount, b.compositionEdgeCount, b.maxCompositionDepth);
 // 6 1 1 — subroutine: 2 more states; 1 composition edge from `call` (depth 1)
 ```
 
-Both programs do the same thing on the same input. The `withSubroutine` version pays for readability — factoring out the walk loop — with 50% more states and one composition edge. `summarize` makes that cost measurable.
+Both programs do the same thing on the same input. The `withSubroutine` version pays for readability — factoring out the walk loop — with 50% more states and one composition edge. `summarizePostMachine` makes that cost measurable.
 
-### Behavioral equivalence — `equivalentOn`
+`summarizePostMachine(machine)` is sugar for `summarize(machine.initialState, machine.tapeBlock)`. The bare `summarize` is also re-exported for callers who already hold a `(state, tapeBlock)` pair.
 
-`equivalentOn(reference, candidate, cases, options?)` is re-exported from `@post-machine-js/machine`. Each side is a `Runnable` of the form `{ state: postMachine.initialState, getTapeBlock: () => postMachine.tapeBlock.clone() }`. **The `getTapeBlock` factory must clone the originating PostMachine's `tapeBlock`** — a fresh `TapeBlock.fromAlphabets([alphabet])` won't work because PostMachine's state graph references symbols interned in the originating block. Each case string is loaded into the cloned tape's cells.
+### Behavioral equivalence — `equivalentPostMachines`
+
+`equivalentPostMachines(reference, candidate, cases, options?)` runs both PostMachine instances against the same list of input tapes and reports per-case agreement, first-divergence step, and per-side step counts.
 
 ```javascript
-import { PostMachine, equivalentOn, check, mark, right, stop } from '@post-machine-js/machine';
+import { PostMachine, equivalentPostMachines, check, mark, right, stop } from '@post-machine-js/machine';
 
 const reference = new PostMachine({
   10: check(20, 30), 20: right(10), 30: mark, 40: stop,
@@ -216,15 +218,13 @@ const candidate = new PostMachine({
   10: check(20, 30), 20: right(10), 30: stop,  // forgot to mark
 });
 
-const report = equivalentOn(
-  { state: reference.initialState, getTapeBlock: () => reference.tapeBlock.clone() },
-  { state: candidate.initialState, getTapeBlock: () => candidate.tapeBlock.clone() },
-  ['** '],
-);
+const report = equivalentPostMachines(reference, candidate, ['** ']);
 console.log(report.allAgree); // false
 ```
 
-Cross-alphabet comparison and the `compareOutputs` / `compareSnapshots` options are documented in the upstream's [equivalence specs](https://github.com/mellonis/turing-machine-js/blob/master/packages/machine/src/utilities/equivalence.spec.ts).
+Each case string is loaded onto a fresh clone of the originating PostMachine's tapeBlock per run (the wrapper handles the cloning — required because state-graph symbols are interned per-block). Cross-alphabet comparison and the `compareOutputs` / `compareSnapshots` options are passed through to upstream `equivalentOn`; see [equivalence specs](https://github.com/mellonis/turing-machine-js/blob/master/packages/machine/src/utilities/equivalence.spec.ts) for full option semantics.
+
+The bare `equivalentOn` is also re-exported. Use it directly when you need a non-PostMachine `Runnable` on either side (e.g., comparing a `PostMachine` against a hand-rolled `TuringMachine`).
 
 ## Links
 

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@post-machine-js/machine",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A convenient Post machine",
   "engines": {
     "npm": ">=7.0.0"
@@ -24,10 +24,10 @@
     "machine"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^3.0.0"
+    "@turing-machine-js/machine": "^3.0.1"
   },
   "devDependencies": {
-    "@turing-machine-js/machine": "^3.0.0"
+    "@turing-machine-js/machine": "^3.0.1"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/machine/src/classes/PostMachine.ts
+++ b/packages/machine/src/classes/PostMachine.ts
@@ -1,4 +1,5 @@
 import {
+  type MachineState,
   Reference,
   State,
   Tape,
@@ -13,14 +14,6 @@ import {
   call, check, erase, left, mark, noop, right, stop,
 } from '../commands';
 import { instructionIndexValidator, subroutineNameValidator } from '../validators';
-
-// Mirror turing's `MachineState` shape by extracting the yielded type from
-// `runStepByStep`'s return signature. turing-machine-js exports the type from
-// its source but doesn't re-export it from the package barrel; this extraction
-// stays in sync if the upstream shape evolves. (Drop in favor of a direct
-// import once turing adds `MachineState` to its index.ts re-exports.)
-type MachineState =
-  ReturnType<TuringMachine['runStepByStep']> extends Generator<infer T> ? T : never;
 
 export class PostMachine extends TuringMachine {
   #initialState: State;

--- a/packages/machine/src/index.ts
+++ b/packages/machine/src/index.ts
@@ -29,3 +29,7 @@ export type {
   CommandContext,
 } from './commands';
 export { PostMachine } from './classes/PostMachine';
+export {
+  summarizePostMachine,
+  equivalentPostMachines,
+} from './wrappers';

--- a/packages/machine/src/wrappers.ts
+++ b/packages/machine/src/wrappers.ts
@@ -1,0 +1,41 @@
+import {
+  type EquivalenceCase,
+  type EquivalenceReport,
+  type GraphSummary,
+  equivalentOn,
+  summarize,
+} from '@turing-machine-js/machine';
+import type { PostMachine } from './classes/PostMachine';
+
+// Post-aware sugar around the upstream introspection / equivalence utilities.
+// They delegate directly — no behavior added — but spare the caller from
+// passing `machine.initialState` and `machine.tapeBlock` (and, for
+// equivalentOn, from getting the per-call tapeBlock factory exactly right).
+
+/**
+ * Sugar for `summarize(machine.initialState, machine.tapeBlock)`.
+ */
+export function summarizePostMachine(machine: PostMachine): GraphSummary {
+  return summarize(machine.initialState, machine.tapeBlock);
+}
+
+/**
+ * Sugar for `equivalentOn` against two `PostMachine` instances. The
+ * `getTapeBlock` factory MUST clone the originating PostMachine's tapeBlock
+ * (PostMachine state-graph symbols are interned per-block; a fresh
+ * `TapeBlock.fromAlphabets([alphabet])` would not match). This wrapper hides
+ * that ceremony.
+ */
+export function equivalentPostMachines(
+  reference: PostMachine,
+  candidate: PostMachine,
+  cases: EquivalenceCase[],
+  options?: Parameters<typeof equivalentOn>[3],
+): EquivalenceReport {
+  return equivalentOn(
+    { state: reference.initialState, getTapeBlock: () => reference.tapeBlock.clone() },
+    { state: candidate.initialState, getTapeBlock: () => candidate.tapeBlock.clone() },
+    cases,
+    options,
+  );
+}

--- a/packages/machine/test/examples.spec.ts
+++ b/packages/machine/test/examples.spec.ts
@@ -4,8 +4,8 @@ import {
   Tape,
   call, check, left, mark, right, stop,
   toMermaid,
-  summarize,
-  equivalentOn,
+  summarizePostMachine,
+  equivalentPostMachines,
 } from '../src/index';
 
 describe('packages/machine/README.md', () => {
@@ -107,7 +107,7 @@ describe('packages/machine/README.md', () => {
       });
     });
 
-    describe('Structural summary — summarize', () => {
+    describe('Structural summary — summarizePostMachine', () => {
       test('inline vs subroutine have different graph shape', () => {
         const inline = new PostMachine({
           10: check(20, 30),
@@ -127,8 +127,8 @@ describe('packages/machine/README.md', () => {
           30: stop,
         });
 
-        const a = summarize(inline.initialState, inline.tapeBlock);
-        const b = summarize(withSubroutine.initialState, withSubroutine.tapeBlock);
+        const a = summarizePostMachine(inline);
+        const b = summarizePostMachine(withSubroutine);
 
         // console.log(a.stateCount, a.compositionEdgeCount, a.maxCompositionDepth); // 4 0 0
         expect(a.stateCount).toBe(4);
@@ -142,7 +142,7 @@ describe('packages/machine/README.md', () => {
       });
     });
 
-    describe('Behavioral equivalence — equivalentOn', () => {
+    describe('Behavioral equivalence — equivalentPostMachines', () => {
       test('reports allAgree false when candidate forgot to mark', () => {
         const reference = new PostMachine({
           10: check(20, 30), 20: right(10), 30: mark, 40: stop,
@@ -151,11 +151,7 @@ describe('packages/machine/README.md', () => {
           10: check(20, 30), 20: right(10), 30: stop,
         });
 
-        const report = equivalentOn(
-          { state: reference.initialState, getTapeBlock: () => reference.tapeBlock.clone() },
-          { state: candidate.initialState, getTapeBlock: () => candidate.tapeBlock.clone() },
-          ['** '],
-        );
+        const report = equivalentPostMachines(reference, candidate, ['** ']);
 
         // console.log(report.allAgree); // false
         expect(report.allAgree).toBe(false);

--- a/packages/machine/test/v3.spec.ts
+++ b/packages/machine/test/v3.spec.ts
@@ -1,7 +1,8 @@
 // Non-README v3 tests — sentinel identity of re-exports, getter sanity,
-// equivalentOn end-to-end. README-driven tests live in examples.spec.ts
-// (one per README — root tests in <repo>/test/examples.spec.ts, per-package
-// tests in <package>/test/examples.spec.ts).
+// equivalentOn end-to-end, and wrapper-vs-manual-call equivalence.
+// README-driven tests live in examples.spec.ts (one per README — root tests
+// in <repo>/test/examples.spec.ts, per-package tests in
+// <package>/test/examples.spec.ts).
 
 import {
   PostMachine,
@@ -11,6 +12,8 @@ import {
   summarize as postSummarize,
   summarizeGraph as postSummarizeGraph,
   equivalentOn as postEquivalentOn,
+  summarizePostMachine,
+  equivalentPostMachines,
   check, mark, right, stop,
 } from '../src/index';
 import {
@@ -106,5 +109,57 @@ describe('equivalentOn end-to-end with PostMachine', () => {
     expect(report.allAgree).toBe(false);
     expect(report.results[0].referenceOutput).toBe('***');
     expect(report.results[0].candidateOutput).toBe('**');
+  });
+});
+
+describe('Post-aware wrappers — equivalence to manual upstream calls', () => {
+  function buildWalkAndMark(): PostMachine {
+    return new PostMachine({
+      10: check(20, 30),
+      20: right(10),
+      30: mark,
+      40: stop,
+    });
+  }
+
+  test('summarizePostMachine matches summarize(initialState, tapeBlock)', () => {
+    const machine = buildWalkAndMark();
+
+    expect(summarizePostMachine(machine))
+      .toEqual(postSummarize(machine.initialState, machine.tapeBlock));
+  });
+
+  test('equivalentPostMachines matches equivalentOn with clone-based getTapeBlock', () => {
+    const reference = buildWalkAndMark();
+    const candidate = buildWalkAndMark();
+
+    const wrapped = equivalentPostMachines(reference, candidate, ['** ']);
+    const manual = postEquivalentOn(
+      { state: reference.initialState, getTapeBlock: () => reference.tapeBlock.clone() },
+      { state: candidate.initialState, getTapeBlock: () => candidate.tapeBlock.clone() },
+      ['** '],
+    );
+
+    // Both should agree (identical machines on identical input). The reports
+    // contain step counts and snapshots that are deterministic for fresh runs,
+    // so toEqual on the full structure is fair.
+    expect(wrapped.allAgree).toBe(true);
+    expect(manual.allAgree).toBe(true);
+    expect(wrapped.results[0].referenceOutput).toBe(manual.results[0].referenceOutput);
+    expect(wrapped.results[0].candidateOutput).toBe(manual.results[0].candidateOutput);
+    expect(wrapped.results[0].referenceSteps).toBe(manual.results[0].referenceSteps);
+    expect(wrapped.results[0].candidateSteps).toBe(manual.results[0].candidateSteps);
+  });
+
+  test('equivalentPostMachines passes through options to upstream equivalentOn', () => {
+    const reference = buildWalkAndMark();
+    const candidate = buildWalkAndMark();
+
+    // compareOutputs that always returns false → wrapper should report disagreement.
+    const report = equivalentPostMachines(reference, candidate, ['** '], {
+      compareOutputs: () => false,
+    });
+
+    expect(report.allAgree).toBe(false);
   });
 });


### PR DESCRIPTION
Patch release adding two Post-aware free-function wrappers around the most-used upstream utilities, plus a small internal cleanup tied to the just-released `@turing-machine-js/machine@3.0.1`.

## Added
- **`summarizePostMachine(machine)`** — sugar for `summarize(machine.initialState, machine.tapeBlock)`.
- **`equivalentPostMachines(reference, candidate, cases, options?)`** — sugar for `equivalentOn` against two `PostMachine` instances. Hides the `getTapeBlock`-must-clone-the-originating-block footgun (PostMachine state-graph symbols are interned per-block; a fresh `TapeBlock.fromAlphabets([alphabet])` doesn't match). Pass-through `options` arg is forwarded to upstream.

Both coexist with the bare upstream re-exports — wrappers are the recommended path for typical use; the bare `summarize` / `equivalentOn` remain available for advanced cases (e.g., comparing a `PostMachine` against a hand-rolled `TuringMachine` via `equivalentOn` directly).

## Changed (internal)
- `MachineState` now imported directly from `@turing-machine-js/machine` (re-exported from its `index.ts` in turing 3.0.1) instead of the prior `Generator<infer T>` extraction. No observable change.
- `peerDependencies['@turing-machine-js/machine']` raised from `^3.0.0` to `^3.0.1`. Required because the new direct `MachineState` import only typechecks against turing 3.0.1+; runtime is unchanged.

## Tests
- Wrapper sentinel tests in `v3.spec.ts`: `summarizePostMachine` output equals manual `summarize(...)` call; `equivalentPostMachines` output equals manual `equivalentOn(...)` call; pass-through `options` work.
- README examples updated to use wrappers; matching tests in `examples.spec.ts`.

## Test plan
- [x] `npm install` — pulls turing 3.0.1
- [x] `npm run build` clean
- [x] `npm run lint` clean
- [x] `npm test` — 4 suites / 96 tests pass (was 93)
- [x] `npx tsc --noEmit` clean
- [ ] CI re-runs all of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)