### PR TITLE
Add GitHub project workflow

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add to project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/mellonis/projects/5
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build](https://github.com/mellonis/post-machine-js/actions/workflows/main.yml/badge.svg)](https://github.com/mellonis/post-machine-js/actions/workflows/main.yml)
 [![Coverage Status](https://coveralls.io/repos/github/mellonis/post-machine-js/badge.svg?branch=master)](https://coveralls.io/github/mellonis/post-machine-js?branch=master)
-![GitHub issues](https://img.shields.io/github/issues/mellonis/post-machine-js)
+[![GitHub issues](https://img.shields.io/github/issues/mellonis/post-machine-js)](https://github.com/users/mellonis/projects/5)
 
 A convenient Post machine.
 


### PR DESCRIPTION
Adds `.github/workflows/add-to-project.yml` to automatically add new issues and PRs to the [@mellonis's machines](https://github.com/users/mellonis/projects/5) project board.

Requires `ADD_TO_PROJECT_PAT` secret to be set on this repo.