### PR TITLE
Allow customizing PostMachine blank and mark symbols

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Key files:
 
 ### Subtleties worth knowing
 
-1. **Module-level singletons**: `originalTapeBlock` and `alphabet` in `consts.ts` are global — `PostMachine` clones the tape block per instance to avoid cross-instance contamination. If you add new built-in commands that need their own per-instance tape state, follow the same clone-per-instance pattern.
+1. **Module-level singletons**: `originalTapeBlock` and `alphabet` in `consts.ts` are global; `PostMachine` clones the tape block per instance to avoid cross-instance contamination. The custom-alphabet path (constructor `options.blankSymbol` / `options.markSymbol`) skips the clone and builds a fresh `TapeBlock.fromAlphabets([new Alphabet([blank, mark])])` instead — the per-instance `#blankSymbol`/`#markSymbol` fields are then threaded into `CommandContext` so `mark`/`erase`/`check` read the chosen glyphs at build time. If you add new built-in commands that need their own per-instance tape state, follow the same clone-per-instance pattern; if they need to reference the alphabet symbols, read them from the context, not from the module-level constants.
 
 2. **Command identity check via `WeakSet`**: `commandsSet` registers every legitimate command-producing function. PostMachine validates user-supplied instructions by checking membership in this set — it's how the runtime distinguishes "user passed a command-producer" from "user passed a random function." Adding new commands requires registering them.
 

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -54,6 +54,34 @@ Reexported from [`@turing-machine-js/machine`](https://github.com/mellonis/turin
 * `blankSymbol` — the blank symbol, ` ` (space).
 * `markSymbol` — the mark symbol, `*`.
 
+## Custom symbols
+
+The Post machine semantics are independent of which two characters represent blank and mark. Pass an options object as the second constructor argument to swap the glyphs — useful for rendering, interop with other formats, or didactic clarity. Both must be single characters and distinct from each other; passing neither (or `undefined` / `null`) falls back to the defaults.
+
+```javascript
+import { PostMachine, check, mark, right, stop, Tape } from '@post-machine-js/machine';
+
+const machine = new PostMachine(
+  {
+    10: check(20, 30),
+    20: right(10),
+    30: mark,
+    40: stop,
+  },
+  { blankSymbol: '.', markSymbol: '#' },
+);
+
+machine.replaceTapeWith(new Tape({
+  alphabet: machine.tape.alphabet,
+  symbols: ['#', '#', '.'],
+}));
+
+machine.run();
+console.log(machine.tape.symbols.join('').replace(/\.+$/, '')); // ###
+```
+
+`mark`, `erase`, and `check` read the chosen symbols from the per-instance alphabet at build time; subroutines and grouped instructions inherit the same alphabet. Build the initial tape against `machine.tape.alphabet` (as in the snippet above) so your tape symbols are validated against the same alphabet the machine was built with.
+
 ## Commands
 
 Each command is a higher-order function. Invoking it with no argument produces a state-producer that advances to the next numbered instruction; invoking with an explicit index jumps to that instruction.

--- a/packages/machine/src/classes/PostMachine.ts
+++ b/packages/machine/src/classes/PostMachine.ts
@@ -1,4 +1,5 @@
 import {
+  Alphabet,
   type MachineState,
   Reference,
   State,
@@ -8,18 +9,45 @@ import {
   ifOtherSymbol,
   haltState,
 } from '@turing-machine-js/machine';
-import { commandsSet, type CommandFn, defaultNextInstructionIndex, originalTapeBlock } from '../consts';
+import {
+  blankSymbol as defaultBlankSymbol,
+  commandsSet,
+  type CommandFn,
+  defaultNextInstructionIndex,
+  markSymbol as defaultMarkSymbol,
+  originalTapeBlock,
+} from '../consts';
 import type { CommandContext, Instructions } from '../commands';
 import {
   call, check, erase, left, mark, noop, right, stop,
 } from '../commands';
-import { instructionIndexValidator, subroutineNameValidator } from '../validators';
+import { instructionIndexValidator, subroutineNameValidator, validateSymbolPair } from '../validators';
+
+export type PostMachineOptions = {
+  blankSymbol?: string;
+  markSymbol?: string;
+};
 
 export class PostMachine extends TuringMachine {
   #initialState: State;
+  #blankSymbol: string;
+  #markSymbol: string;
 
-  constructor(instructions: Instructions = {}) {
-    super({ tapeBlock: originalTapeBlock.clone() });
+  constructor(instructions: Instructions = {}, options: PostMachineOptions = {}) {
+    const blankSymbol = options.blankSymbol ?? defaultBlankSymbol;
+    const markSymbol = options.markSymbol ?? defaultMarkSymbol;
+
+    validateSymbolPair(blankSymbol, markSymbol);
+
+    const usesDefaultAlphabet = blankSymbol === defaultBlankSymbol && markSymbol === defaultMarkSymbol;
+    const tapeBlock = usesDefaultAlphabet
+      ? originalTapeBlock.clone()
+      : TapeBlock.fromAlphabets([new Alphabet([blankSymbol, markSymbol])]);
+
+    super({ tapeBlock });
+
+    this.#blankSymbol = blankSymbol;
+    this.#markSymbol = markSymbol;
 
     this.#initialState = this.#buildInitialState({
       instructions,
@@ -167,6 +195,8 @@ export class PostMachine extends TuringMachine {
           states,
           subroutineInitialStates,
           calledFromGroup,
+          blankSymbol: this.#blankSymbol,
+          markSymbol: this.#markSymbol,
         };
         builtStates.set(String(instructionIndex), (instruction as (context: CommandContext) => State)(context));
       } else if (Array.isArray(instruction)) {

--- a/packages/machine/src/commands.ts
+++ b/packages/machine/src/commands.ts
@@ -4,7 +4,7 @@ import {
 
 type StateOrRef = State | Reference;
 import {
-  blankSymbol, commandsSet, type CommandFn, defaultNextInstructionIndex, markSymbol,
+  commandsSet, type CommandFn, defaultNextInstructionIndex,
 } from './consts';
 import { instructionIndexValidator, subroutineNameValidator } from './validators';
 
@@ -16,6 +16,8 @@ export type CommandContext = {
   tapeBlock: TapeBlock;
   subroutineInitialStates: Record<string, State>;
   calledFromGroup: boolean;
+  blankSymbol: string;
+  markSymbol: string;
 };
 
 // A bound state-producer — what each command function returns when called.
@@ -109,7 +111,7 @@ function checkCommandStateProducer(this: {
   nextInstructionIndexIfMarked: number;
   nextInstructionIndexOtherwise: number;
 }, {
-  instructionIndex, references, states, tapeBlock, calledFromGroup,
+  instructionIndex, references, states, tapeBlock, calledFromGroup, blankSymbol, markSymbol,
 }: CommandContext): State {
   if (calledFromGroup) {
     throw new Error('the \'check\' command cannot be used in a group');
@@ -161,14 +163,18 @@ type UnaryCommand = { symbol?: string; movement?: symbol };
 // Factory for the five "unary" commands (erase, left, mark, noop, right) that
 // share an identical state-producer skeleton. They differ only in:
 //   - `hashPrefix`: a unique cache-key tag per command kind
-//   - `command`: the per-tape TapeCommand to issue (or `null` for noop)
+//   - `buildCommand`: a function that, given the build-time context, returns
+//     the per-tape TapeCommand to issue (or `null` for noop). Resolving the
+//     command at producer-call time (not factory-call time) lets `mark`/`erase`
+//     read per-instance `blankSymbol`/`markSymbol` from the context.
 function makeUnaryCommandProducer(
   hashPrefix: string,
-  command: UnaryCommand | null,
+  buildCommand: ((ctx: CommandContext) => UnaryCommand) | null,
 ): (this: { nextInstructionIndex?: number | symbol }, ctx: CommandContext) => State {
-  return function unaryCommandStateProducer(this: { nextInstructionIndex?: number | symbol }, {
-    instructionIndex, nextInstructionIndex, references, states, calledFromGroup,
-  }: CommandContext): State {
+  return function unaryCommandStateProducer(this: { nextInstructionIndex?: number | symbol }, ctx: CommandContext): State {
+    const {
+      instructionIndex, nextInstructionIndex, references, states, calledFromGroup,
+    } = ctx;
     let { nextInstructionIndex: boundNextInstructionIndex } = this;
 
     if (calledFromGroup && boundNextInstructionIndex !== defaultNextInstructionIndex) {
@@ -205,7 +211,7 @@ function makeUnaryCommandProducer(
       return states.get(hash)!;
     }
 
-    const transition = command === null ? { nextState } : { command: [command], nextState };
+    const transition = buildCommand === null ? { nextState } : { command: [buildCommand(ctx)], nextState };
     const state = new State({ [ifOtherSymbol]: transition });
 
     states.set(hash, state);
@@ -214,11 +220,11 @@ function makeUnaryCommandProducer(
   };
 }
 
-const eraseCommandStateProducer = makeUnaryCommandProducer(':eraseFn:', { symbol: blankSymbol });
-const leftCommandStateProducer = makeUnaryCommandProducer(':leftFn:', { movement: movements.left });
-const markCommandStateProducer = makeUnaryCommandProducer(':markFn:', { symbol: markSymbol });
+const eraseCommandStateProducer = makeUnaryCommandProducer(':eraseFn:', (ctx) => ({ symbol: ctx.blankSymbol }));
+const leftCommandStateProducer = makeUnaryCommandProducer(':leftFn:', () => ({ movement: movements.left }));
+const markCommandStateProducer = makeUnaryCommandProducer(':markFn:', (ctx) => ({ symbol: ctx.markSymbol }));
 const noopCommandStateProducer = makeUnaryCommandProducer(':noopFn:', null);
-const rightCommandStateProducer = makeUnaryCommandProducer(':rightFn:', { movement: movements.right });
+const rightCommandStateProducer = makeUnaryCommandProducer(':rightFn:', () => ({ movement: movements.right }));
 
 function stopCommandStateProducer(this: null, { calledFromGroup }: CommandContext): State {
   if (calledFromGroup) {

--- a/packages/machine/src/index.ts
+++ b/packages/machine/src/index.ts
@@ -29,6 +29,7 @@ export type {
   CommandContext,
 } from './commands';
 export { PostMachine } from './classes/PostMachine';
+export type { PostMachineOptions } from './classes/PostMachine';
 export {
   summarizePostMachine,
   equivalentPostMachines,

--- a/packages/machine/src/validators.ts
+++ b/packages/machine/src/validators.ts
@@ -9,3 +9,15 @@ const subroutineNameRegex = /^[A-Z$_][A-Z0-9$_]*$/i;
 export function subroutineNameValidator(subroutineName: string): boolean {
   return subroutineNameRegex.test(subroutineName) && subroutineName !== 'undefined';
 }
+
+export function validateSymbolPair(blankSymbol: unknown, markSymbol: unknown): void {
+  if (typeof blankSymbol !== 'string' || blankSymbol.length !== 1) {
+    throw new Error('blankSymbol must be a single character');
+  }
+  if (typeof markSymbol !== 'string' || markSymbol.length !== 1) {
+    throw new Error('markSymbol must be a single character');
+  }
+  if (blankSymbol === markSymbol) {
+    throw new Error('blankSymbol and markSymbol must be distinct');
+  }
+}

--- a/packages/machine/test/custom-alphabet.spec.ts
+++ b/packages/machine/test/custom-alphabet.spec.ts
@@ -1,0 +1,253 @@
+import {
+  PostMachine, Tape, alphabet, blankSymbol, call, check, erase, left, mark, markSymbol, right, stop,
+  summarizePostMachine,
+} from '../src/index';
+import { getRandomInstructionIndex } from './helpers';
+
+describe('PostMachine custom alphabet', () => {
+  describe('default behavior (no options)', () => {
+    test('uses the module-level blank/mark symbols', () => {
+      const machine = new PostMachine({ 1: stop });
+
+      expect(machine.tape.alphabet.blankSymbol).toBe(blankSymbol);
+      expect(machine.tape.alphabet.symbols).toEqual(alphabet.symbols);
+      expect(machine.tape.alphabet.symbols).toEqual([' ', '*']);
+      expect(machine.tape.alphabet.has(markSymbol)).toBe(true);
+    });
+  });
+
+  describe('options validation', () => {
+    test.each<[string, unknown, unknown]>([
+      ['blankSymbol must be a single character', '..', '#'],
+      ['blankSymbol must be a single character', '', '#'],
+      ['blankSymbol must be a single character', 0, '#'],
+      ['markSymbol must be a single character', '.', '##'],
+      ['markSymbol must be a single character', '.', ''],
+      ['markSymbol must be a single character', '.', 0],
+      ['blankSymbol and markSymbol must be distinct', '.', '.'],
+    ])('throws "%s"', (message, blank, mark) => {
+      expect(() => new PostMachine(
+        { 1: stop },
+        { blankSymbol: blank as string, markSymbol: mark as string },
+      )).toThrow(message);
+    });
+
+    test('null/undefined fall back to defaults (not validation errors)', () => {
+      // ?? operator treats null and undefined as "use default"; only an
+      // explicit non-string-or-wrong-length value should fail validation.
+      const m1 = new PostMachine({ 1: stop }, { blankSymbol: undefined, markSymbol: undefined });
+      expect(m1.tape.alphabet.symbols).toEqual([' ', '*']);
+
+      const m2 = new PostMachine({ 1: stop }, { blankSymbol: null as unknown as string });
+      expect(m2.tape.alphabet.symbols).toEqual([' ', '*']);
+    });
+  });
+
+  describe('partial overrides', () => {
+    test('only blankSymbol overridden — markSymbol falls back to default', () => {
+      const machine = new PostMachine({ 1: stop }, { blankSymbol: '.' });
+
+      expect(machine.tape.alphabet.symbols).toEqual(['.', '*']);
+    });
+
+    test('only markSymbol overridden — blankSymbol falls back to default', () => {
+      const machine = new PostMachine({ 1: stop }, { markSymbol: '#' });
+
+      expect(machine.tape.alphabet.symbols).toEqual([' ', '#']);
+    });
+
+    test('partial override that collides with the default of the other symbol throws', () => {
+      // mark default is '*'; setting blank to '*' collides.
+      expect(() => new PostMachine({ 1: stop }, { blankSymbol: '*' }))
+        .toThrow('blankSymbol and markSymbol must be distinct');
+    });
+  });
+
+  describe('full override', () => {
+    test('builds a per-instance alphabet with the chosen symbols', () => {
+      const machine = new PostMachine({ 1: stop }, { blankSymbol: '.', markSymbol: '#' });
+
+      expect(machine.tape.alphabet.symbols).toEqual(['.', '#']);
+      expect(machine.tape.alphabet.blankSymbol).toBe('.');
+    });
+
+    test('mark writes the chosen mark symbol', () => {
+      const machine = new PostMachine(
+        { 1: mark, 2: stop },
+        { blankSymbol: '.', markSymbol: '#' },
+      );
+
+      machine.replaceTapeWith(new Tape({
+        alphabet: machine.tape.alphabet,
+        symbols: ['.'],
+      }));
+
+      machine.run();
+
+      expect(machine.tape.symbols.join('')).toBe('#');
+    });
+
+    test('erase writes the chosen blank symbol', () => {
+      const machine = new PostMachine(
+        { 1: erase, 2: stop },
+        { blankSymbol: '.', markSymbol: '#' },
+      );
+
+      machine.replaceTapeWith(new Tape({
+        alphabet: machine.tape.alphabet,
+        symbols: ['#'],
+      }));
+
+      machine.run();
+
+      expect(machine.tape.symbols.join('')).toBe('.');
+    });
+
+    test('check branches on the chosen mark/blank symbols', () => {
+      // Same program as the README quick start, but with .#  alphabet:
+      // walk right while marked, write a mark on the first blank.
+      const machine = new PostMachine(
+        {
+          10: check(20, 30),
+          20: right(10),
+          30: mark,
+          40: stop,
+        },
+        { blankSymbol: '.', markSymbol: '#' },
+      );
+
+      machine.replaceTapeWith(new Tape({
+        alphabet: machine.tape.alphabet,
+        symbols: ['#', '#', '.'],
+      }));
+
+      machine.run();
+
+      expect(machine.tape.symbols.join('').replace(/\.+$/, '')).toBe('###');
+    });
+
+    test('left/right/noop work with custom alphabet (no symbol writes)', () => {
+      const ix = getRandomInstructionIndex();
+      const next = ix + 1;
+
+      const machine = new PostMachine(
+        { [ix]: right(next), [next]: stop },
+        { blankSymbol: '.', markSymbol: '#' },
+      );
+
+      machine.replaceTapeWith(new Tape({
+        alphabet: machine.tape.alphabet,
+        symbols: ['#', '.', '#'],
+        position: 0,
+      }));
+
+      machine.run();
+
+      // head moved right by one; tape contents unchanged
+      expect(machine.tape.symbols.join('')).toBe('#.#');
+    });
+
+    test('subroutines inherit the custom alphabet', () => {
+      const machine = new PostMachine(
+        {
+          rightToBlank: {
+            1: right,
+            2: check(1, 3),
+            3: stop,
+          },
+          1: call('rightToBlank'),
+          2: mark,
+          3: stop,
+        },
+        { blankSymbol: '.', markSymbol: '#' },
+      );
+
+      machine.replaceTapeWith(new Tape({
+        alphabet: machine.tape.alphabet,
+        symbols: ['#', '#', '.'],
+      }));
+
+      machine.run();
+
+      expect(machine.tape.symbols.join('').replace(/\.+$/, '')).toBe('###');
+    });
+
+    test('groups inherit the custom alphabet', () => {
+      // group: write mark, then move right.
+      const machine = new PostMachine(
+        {
+          1: [mark, right],
+          2: stop,
+        },
+        { blankSymbol: '.', markSymbol: '#' },
+      );
+
+      machine.replaceTapeWith(new Tape({
+        alphabet: machine.tape.alphabet,
+        symbols: ['.', '.'],
+      }));
+
+      machine.run();
+
+      expect(machine.tape.symbols.join('')).toBe('#.');
+    });
+
+    test('summarizePostMachine still reports tapeCount: 1, alphabetCardinalities: [2]', () => {
+      const machine = new PostMachine(
+        {
+          10: check(20, 30),
+          20: right(10),
+          30: mark,
+          40: stop,
+        },
+        { blankSymbol: '.', markSymbol: '#' },
+      );
+
+      const summary = summarizePostMachine(machine);
+
+      expect(summary.tapeCount).toBe(1);
+      expect(summary.alphabetCardinalities).toEqual([2]);
+    });
+
+    test('non-ASCII glyphs work (Unicode open box / heavy dot)', () => {
+      const machine = new PostMachine(
+        {
+          10: check(20, 30),
+          20: right(10),
+          30: mark,
+          40: stop,
+        },
+        { blankSymbol: '␣', markSymbol: '•' },
+      );
+
+      machine.replaceTapeWith(new Tape({
+        alphabet: machine.tape.alphabet,
+        symbols: ['•', '•', '␣'],
+      }));
+
+      machine.run();
+
+      expect(machine.tape.symbols.join('').replace(/␣+$/, '')).toBe('•••');
+    });
+  });
+
+  describe('left/right/noop unaffected by custom alphabet', () => {
+    test('left moves head one cell to the left regardless of symbols', () => {
+      const machine = new PostMachine(
+        { 1: left(2), 2: stop },
+        { blankSymbol: '.', markSymbol: '#' },
+      );
+
+      machine.replaceTapeWith(new Tape({
+        alphabet: machine.tape.alphabet,
+        symbols: ['#', '#'],
+        position: 1,
+      }));
+
+      machine.run();
+
+      // After one left move, head sits at position 0; symbols unchanged.
+      expect(machine.tape.symbols.join('')).toBe('##');
+    });
+  });
+});

--- a/packages/machine/test/examples.spec.ts
+++ b/packages/machine/test/examples.spec.ts
@@ -89,6 +89,31 @@ describe('packages/machine/README.md', () => {
     });
   });
 
+  describe('Custom symbols', () => {
+    test('## → marks first . to make ### with .# alphabet', () => {
+      const machine = new PostMachine(
+        {
+          10: check(20, 30),
+          20: right(10),
+          30: mark,
+          40: stop,
+        },
+        { blankSymbol: '.', markSymbol: '#' },
+      );
+
+      machine.replaceTapeWith(new Tape({
+        alphabet: machine.tape.alphabet,
+        symbols: ['#', '#', '.'],
+      }));
+
+      machine.run();
+
+      // console.log(machine.tape.symbols.join('').replace(/\.+$/, '')); // ###
+      expect(machine.tape.symbols.join('').replace(/\.+$/, ''))
+        .toBe('###');
+    });
+  });
+
   describe('Introspection and equivalence', () => {
     describe('Visualization — toMermaid + State.toGraph', () => {
       test('first line is "flowchart TD"', () => {


### PR DESCRIPTION
Closes #55.

## Summary

- Adds optional second constructor arg `new PostMachine(instructions, { blankSymbol?, markSymbol? })`.
- When either symbol is overridden, the constructor builds a per-instance `Alphabet` + `TapeBlock`. The default path still clones `originalTapeBlock` to keep existing behavior identical.
- `CommandContext` gains `blankSymbol` and `markSymbol`; `mark` / `erase` / `check` now read these from the context instead of the module-level constants. `left` / `right` / `noop` are unaffected (no symbol writes).
- New `validateSymbolPair` rejects multi-char or equal symbols up front with a clear message; `null` / `undefined` fall back to the defaults via `??`.

## Public API

- `PostMachine` constructor signature widened — the second arg is optional, so existing callers compile and run unchanged.
- New exported type `PostMachineOptions`.
- `blankSymbol` / `markSymbol` / `alphabet` module exports unchanged — they remain the defaults.

## Tests

- 22 new tests in `packages/machine/test/custom-alphabet.spec.ts` covering: default path regression, validation errors, partial overrides, full override (`mark`/`erase`/`check` semantics, subroutines, groups, `summarizePostMachine` invariants, non-ASCII glyphs `␣` / `•`).
- New `Custom symbols` README example with matching test in `examples.spec.ts` (per repo doc-parity rule).
- Full suite: 119 tests passing (was 96).

## Known limitation (out of scope)

`equivalentPostMachines` clones the *originating* tapeBlock per case. Comparing a custom-alphabet machine against a default-alphabet machine via the wrapper will hit symbol-interning mismatches in upstream `equivalentOn`. Cross-alphabet equivalence is an upstream concern; the bare `equivalentOn` re-export is the existing escape hatch. Worth a follow-up if it bites in practice.

## Test plan

- [x] `npm test` — 119 passing (was 96, +22 new + 1 README example).
- [x] `npm run lint` — clean.
- [x] `npm run build` — builds; pre-existing Rollup `this`-at-module-top warnings are unchanged.