### PR TITLE
v3.1.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.1",
+  "version": "3.1.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13475,7 +13475,7 @@
     },
     "packages/machine": {
       "name": "@post-machine-js/machine",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@turing-machine-js/machine": "^3.0.1"

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-05-05
+
+### Added
+
+- **`PostMachine` constructor accepts an optional second argument** `{ blankSymbol?: string; markSymbol?: string }` that selects the two glyphs used by the per-instance alphabet. Defaults to `' '` / `'*'` so existing callers are unaffected. Each must be a single character and distinct from the other; `null` / `undefined` fall back to the default. ([#55](https://github.com/mellonis/post-machine-js/issues/55))
+- **`PostMachineOptions`** type re-exported from the package entry for callers that want to factor out the options bag.
+
+### Changed (internal)
+
+- `CommandContext` gains `blankSymbol` and `markSymbol`; `mark` / `erase` / `check` read them from the context at build time instead of closing over the module-level constants. `left` / `right` / `noop` are unaffected (no symbol writes). When the constructor receives a non-default symbol, a fresh `TapeBlock.fromAlphabets([new Alphabet([blank, mark])])` is built per instance; the default path still clones `originalTapeBlock` to preserve existing behavior bit-for-bit.
+
 ## [3.0.1] - 2026-04-30
 
 ### Added

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@post-machine-js/machine",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "A convenient Post machine",
   "engines": {
     "npm": ">=7.0.0"


### PR DESCRIPTION
Release PR for `@post-machine-js/machine` **v3.1.0**.

## Summary

Minor release: a `PostMachine` instance can now pick its own blank and mark symbols.

## Changes

- `lerna.json` and `packages/machine/package.json` bumped 3.0.1 → 3.1.0.
- `package-lock.json` regenerated.
- `packages/machine/CHANGELOG.md` — `[3.1.0] - 2026-05-05` entry covering the constructor option and the `PostMachineOptions` re-export.

## Feature already on master

The actual feature work landed via #56 (closes #55). This PR is bump-only — versions, lock, changelog.

## Test plan

- [x] `npm test` — 119 passing.
- [x] `npm run lint` — clean.
- [x] `npm run build` — builds; pre-existing Rollup `this`-at-module-top warnings unchanged.
- [ ] After merge: `npm publish` from `packages/machine/` (manual).