### PR TITLE
fix: await user onStep in PostMachine.run internal wrapper

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
           node-version: '24'
       - run: npm ci
       - run: npm run lint
+      - run: npm run typecheck
       - run: npm run test:coverage
       - name: Coveralls
         uses: coverallsapp/github-action@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@turing-machine-js/machine": "^6.0.1"
+        "@turing-machine-js/machine": "^6.2.0"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.13",
@@ -2740,9 +2740,9 @@
       }
     },
     "node_modules/@turing-machine-js/machine": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-6.0.1.tgz",
-      "integrity": "sha512-nnp1z8bmGa+OBe9nPi8JloATkj5Aa6KSbjj/9SZ8k+evFvLs96s0tvbAD8+Pivf1Jc/zngWKkC9dCwtdyE/cYQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-6.2.0.tgz",
+      "integrity": "sha512-Lx2LJqy4NXAj8fNsyMO+jIHc6ZCqxMPh5LcXVnpSGAeXTPnGhRHLfXtEpIlRwSIYmui4eIuSfephka1gkycmiQ==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10441,7 +10441,7 @@
     },
     "packages/machine": {
       "name": "@post-machine-js/machine",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@turing-machine-js/machine": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@turing-machine-js/machine": "^6.0.1"
+    "@turing-machine-js/machine": "^6.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit -p packages/machine/tsconfig.json"
   },
   "author": "Ruslan Gilmullin <mellonis@yandex.ru>",
   "workspaces": [

--- a/packages/machine/src/classes/PostMachine.ts
+++ b/packages/machine/src/classes/PostMachine.ts
@@ -106,7 +106,7 @@ export class PostMachine extends TuringMachine {
     onPause,
   }: {
     stepsLimit?: number;
-    onStep?: (machineState: MachineState) => void;
+    onStep?: (machineState: MachineState) => void | Promise<void>;
     onPause?: (machineState: MachineState) => void | Promise<void>;
   } = {}): Promise<void> {
     let prevState: State | null = null;
@@ -124,9 +124,9 @@ export class PostMachine extends TuringMachine {
     await super.run({
       initialState: this.#initialState,
       stepsLimit,
-      onStep: (raw) => {
+      onStep: async (raw) => {
         const wrapped = this.#wrapMachineState(raw, prevState, prevJsSymbol, entryPath);
-        if (onStep) onStep(wrapped);
+        if (onStep) await onStep(wrapped);
         advanceTracking(raw);
       },
       onPause: onPause ? async (raw) => {

--- a/packages/machine/test/breakpoints.spec.ts
+++ b/packages/machine/test/breakpoints.spec.ts
@@ -149,9 +149,12 @@ describe('pm.clearBreakpoint / clearBreakpoints', () => {
     pm.setBreakpoint('10', { before: true });
     pm.clearBreakpoint('10');
     expect(pm.listBreakpoints()).toEqual([]);
-    // Engine v6.1+ (#150) returns an empty `DebugConfig` after a filters reset
-    // rather than `null` — behaviorally equivalent (no break fires).
-    expect(pm.stateAt('10').debug).toEqual({});
+    // Engine v6.1+ (#150) returns an empty `DebugConfig` after a filters
+    // reset rather than `null`. Check the public getters directly — `undefined`
+    // is the "no filter set" sentinel (field type: `symbol[] | true | undefined`).
+    const dbg = pm.stateAt('10').debug;
+    expect(dbg.before).toBeUndefined();
+    expect(dbg.after).toBeUndefined();
   });
 
   test('clearBreakpoint on a shared State shrinks the union filter', () => {
@@ -182,7 +185,9 @@ describe('pm.clearBreakpoint / clearBreakpoints', () => {
     pm.clearBreakpoints();
     expect(pm.listBreakpoints()).toEqual([]);
     // Engine v6.1+ (#150) — see clearBreakpoint test above.
-    expect(pm.stateAt('10').debug).toEqual({});
+    const dbg = pm.stateAt('10').debug;
+    expect(dbg.before).toBeUndefined();
+    expect(dbg.after).toBeUndefined();
   });
 });
 

--- a/packages/machine/test/breakpoints.spec.ts
+++ b/packages/machine/test/breakpoints.spec.ts
@@ -144,12 +144,14 @@ describe('pm.setBreakpoint / listBreakpoints', () => {
 });
 
 describe('pm.clearBreakpoint / clearBreakpoints', () => {
-  test('clearBreakpoint removes one entry and resets state.debug to null', () => {
+  test('clearBreakpoint removes one entry and clears state.debug filters', () => {
     const pm = new PostMachine({ 10: mark, 20: stop });
     pm.setBreakpoint('10', { before: true });
     pm.clearBreakpoint('10');
     expect(pm.listBreakpoints()).toEqual([]);
-    expect(pm.stateAt('10').debug).toBeNull();
+    // Engine v6.1+ (#150) returns an empty `DebugConfig` after a filters reset
+    // rather than `null` — behaviorally equivalent (no break fires).
+    expect(pm.stateAt('10').debug).toEqual({});
   });
 
   test('clearBreakpoint on a shared State shrinks the union filter', () => {
@@ -179,7 +181,8 @@ describe('pm.clearBreakpoint / clearBreakpoints', () => {
     pm.setBreakpoint(haltState, { before: true });
     pm.clearBreakpoints();
     expect(pm.listBreakpoints()).toEqual([]);
-    expect(pm.stateAt('10').debug).toBeNull();
+    // Engine v6.1+ (#150) — see clearBreakpoint test above.
+    expect(pm.stateAt('10').debug).toEqual({});
   });
 });
 

--- a/packages/machine/test/lockdown.spec.ts
+++ b/packages/machine/test/lockdown.spec.ts
@@ -77,7 +77,9 @@ describe('installStateLockdown', () => {
       // After the inner escape ends, the outer is still active.
       s.debug = null;
     });
-    expect(s.debug).toBeNull();
+    // Engine v6.1+ (#150) returns an empty `DebugConfig` after `state.debug = null`
+    // (filters cleared) rather than literal `null`.
+    expect(s.debug).toEqual({});
   });
 });
 

--- a/packages/machine/test/lockdown.spec.ts
+++ b/packages/machine/test/lockdown.spec.ts
@@ -78,8 +78,10 @@ describe('installStateLockdown', () => {
       s.debug = null;
     });
     // Engine v6.1+ (#150) returns an empty `DebugConfig` after `state.debug = null`
-    // (filters cleared) rather than literal `null`.
-    expect(s.debug).toEqual({});
+    // (filters cleared) rather than literal `null`. Check the public getters
+    // directly — `undefined` is the "no filter set" sentinel.
+    expect(s.debug.before).toBeUndefined();
+    expect(s.debug.after).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Three related fixes that ship together because they're all needed before post-machine-js can consume any engine v6.1.0+:

1. **`await` user `onStep` in `PostMachine.run`'s internal wrapper.** Companion to [`mellonis/turing-machine-js#159`](https://github.com/mellonis/turing-machine-js/pull/159) (await onStep in the engine, shipped in [v6.2.0](https://github.com/mellonis/turing-machine-js/releases/tag/v6.2.0)). PostMachine wraps `super.run`'s `onStep` to inject `prevState` tracking + `MachineState` wrapping; that internal wrapper now `await`s the user-supplied `onStep` before `advanceTracking` runs. Without it, an async user `onStep` returns a Promise that the wrapper discards, defeating the engine's new await. `onStep` type widened: `(m: MachineState) => void` → `(m: MachineState) => void | Promise<void>`.

2. **Engine v6.1+ `DebugConfig` compat in 3 tests.** Engine [#150](https://github.com/mellonis/turing-machine-js/issues/150) (v6.1.0) changed `state.debug = null` semantics: instead of returning literal `null` on the next read, it now returns a fresh empty `DebugConfig`. Three assertions asserted `state.debug === null` and broke against any engine ≥ v6.1.0 (including v6.2.0). Updated to check the public getters directly: `before === undefined && after === undefined` — the "no filter set" sentinel per the engine's `DebugConfig` field types (`symbol[] | true | undefined`).

3. **CI `typecheck` step.** Mirrors the same fix in the engine PR ([#159](https://github.com/mellonis/turing-machine-js/pull/159)). `npm run build` excludes `*.spec.ts` and vitest's esbuild doesn't type-check, so spec-file type errors could previously slip through CI.

## Dep change

`@turing-machine-js/machine` dependency bumped `^6.0.1` → `^6.2.0` in the root `package.json` so `npm install` pulls in the engine release. Peer-dep range in `packages/machine/package.json` stays at `^6.0.0` — once consumers are on engine v6.2.0 they get the awaited-onStep behavior, and consumers on v6.0.x / v6.1.x still install fine (the type widening is forward-compatible).

## Test plan
- [x] `npm test` — 265/265 pass against the published engine v6.2.0
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean