### PR TITLE
feat: per-package build + `prepublishOnly` hook (closes #80)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.0.0",
+  "version": "6.4.0",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -5,6 +5,10 @@
   "engines": {
     "npm": ">=7.0.0"
   },
+  "scripts": {
+    "build": "tsc --build --verbose tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@post-machine-js/machine",
+    "prepublishOnly": "npm run build"
+  },
   "author": "Ruslan Gilmullin <mellonis@yandex.ru>",
   "homepage": "https://github.com/mellonis/post-machine-js#readme",
   "license": "GPL-3.0-or-later",

--- a/scripts/build-node-entries.mjs
+++ b/scripts/build-node-entries.mjs
@@ -1,33 +1,51 @@
 import { rollup } from 'rollup';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const packages = [
+// Resolve paths relative to the repo root (this script's parent's parent),
+// so the script behaves the same whether invoked from root (`npm run build`)
+// or from a sub-package (`packages/X/ $ npm run build`).
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Optional `--package=<scoped-name>` filter — when present, build only that
+// package's Node entries; otherwise build all. Per-package `prepublishOnly`
+// hooks pass the flag so each publish only Rollups its own package, while
+// the root's `npm run build` (no flag) batches all.
+const pkgFlag = process.argv.slice(2).find((a) => a.startsWith('--package='));
+const requestedPkg = pkgFlag ? pkgFlag.slice('--package='.length) : null;
+
+const allPackages = [
   {
     name: '@post-machine-js/machine',
-    entry: 'packages/machine/dist/index.js',
-    outputs: {
-      esm: 'packages/machine/dist/index.mjs',
-      cjs: 'packages/machine/dist/index.cjs',
-    },
-    external: [
-      '@turing-machine-js/machine',
-    ],
+    dir: 'packages/machine',
+    external: ['@turing-machine-js/machine'],
   },
 ];
 
+const packages = requestedPkg
+  ? allPackages.filter((p) => p.name === requestedPkg)
+  : allPackages;
+
+if (requestedPkg && packages.length === 0) {
+  console.error(`Unknown package: ${requestedPkg}`);
+  console.error(`Known: ${allPackages.map((p) => p.name).join(', ')}`);
+  process.exit(1);
+}
+
 for (const pkg of packages) {
   const bundle = await rollup({
-    input: pkg.entry,
+    input: resolve(REPO_ROOT, pkg.dir, 'dist/index.js'),
     external: pkg.external,
   });
 
   await bundle.write({
-    file: pkg.outputs.esm,
+    file: resolve(REPO_ROOT, pkg.dir, 'dist/index.mjs'),
     format: 'es',
     exports: 'auto',
   });
 
   await bundle.write({
-    file: pkg.outputs.cjs,
+    file: resolve(REPO_ROOT, pkg.dir, 'dist/index.cjs'),
     format: 'cjs',
     exports: 'auto',
   });


### PR DESCRIPTION
## Summary

Mirrors [turing-machine-js#154](https://github.com/mellonis/turing-machine-js/pull/154) shape so post-machine-js releases stop risking stale-\`dist/\` publishes, and aligns the release workflow uniformly across both repos.

Discovered just before v6.4.0 publish: \`packages/machine/package.json\` had no \`scripts\` block. Manual \`npm run build\` from root before \`npm publish\` was the only thing keeping dist current. After a session of edits, \`dist/\` was 105 minutes older than source — would have shipped stale code without the manual rebuild.

## What changes

- **\`scripts/build-node-entries.mjs\`** — paths resolve via \`REPO_ROOT\` from \`import.meta.url\`, so the script behaves the same from root or from a sub-package. Optional \`--package=<scoped-name>\` filter for per-package builds (only one package in this repo, but matches engine's shape).
- **\`packages/machine/package.json\`** — new \`scripts\` block:
  \`\`\`json
  "scripts": {
    "build": "tsc --build --verbose tsconfig.build.json && node ../../scripts/build-node-entries.mjs --package=@post-machine-js/machine",
    "prepublishOnly": "npm run build"
  }
  \`\`\`
  \`npm publish\` (or \`lerna publish from-package\`) from \`packages/machine/\` now auto-builds first.
- **\`lerna.json\`** — version synced \`6.0.0\` → \`6.4.0\` (was stale; hand-edited bumps don't touch \`lerna.json\`, so it had drifted across all post-machine-js releases since v6.0.0).

## After this lands — uniform release workflow across both repos

| Step | Command |
|---|---|
| Bump | \`npx lerna version <X.Y.Z> --no-git-tag-version --no-push --yes\` |
| Publish | \`npx lerna publish from-package --yes\` (from repo root) |
| GH release | \`gh release create vX.Y.Z --target master --title vX.Y.Z --notes-file <path>\` |

Same commands for both repos; per-repo branch-name conventions remain the only difference (\`chore/release-X.Y.Z\` for turing-machine-js, \`vX-Y-Z\` for post-machine-js).

## Umbrella docs update

The umbrella [\`mellonis/machines/CLAUDE.md\`](https://github.com/mellonis/machines)'s "Release / delivery process" section will be updated to reflect the uniform flow. Direct push to umbrella master (per the established pattern — umbrella allows direct).

## Compatibility

- **No source / API changes.** Infrastructure only.
- **No version bump.** Next release picks up the prepublishOnly hook automatically.

## Test plan
- [x] \`cd packages/machine && rm -rf dist && npm publish --dry-run\` triggers prepublishOnly, rebuilds dist, prepares 50.9 kB tarball (15 files, version 6.4.0).
- [x] \`npx lerna list --json\` from root reports \`@post-machine-js/machine\` at 6.4.0 — \`lerna publish from-package\` will publish it.
- [x] \`npm test\` — 267/267
- [x] \`npm run typecheck\` / \`npm run lint\` / \`npm run build\` from root — all clean