### PR TITLE
feat(PostMachine): drop subroutine hopper for acyclic plain-first-instruction case (#85)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.0.0-alpha.2",
+  "version": "7.0.0-alpha.3",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10441,7 +10441,7 @@
     },
     "packages/machine": {
       "name": "@post-machine-js/machine",
-      "version": "7.0.0-alpha.2",
+      "version": "7.0.0-alpha.3",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@turing-machine-js/machine": "^7.0.0-alpha.2"

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0-alpha.3] - 2026-05-21
+
+Third v7 pre-release. Drops the v6.x subroutine "hopper" State for the common case where it's not needed for forward-declaration ([#85](https://github.com/mellonis/post-machine-js/issues/85)). Engine peer-dep unchanged (`^7.0.0-alpha.2`). Published to npm under the `next` dist-tag: `npm install @post-machine-js/machine@next`.
+
+**Pre-release — the API surface may still shift before stable v7.0.0.** Pin to a specific alpha for reproducibility: `@post-machine-js/machine@7.0.0-alpha.3`.
+
+### Changed
+
+- **Subroutine hopper dropped for acyclic subroutines with plain first instruction** ([#85](https://github.com/mellonis/post-machine-js/issues/85)). PostMachine used to create a "hopper" State per subroutine — a stub State that wrapped a `Reference` to the subroutine's first instruction, providing a forward-declaration anchor for `withOverriddenHaltState`. For the common case, the hopper is now dropped: `call('foo')` wraps `foo::1` directly, saving one State per call site.
+
+  The hopper is **retained** in three cases where dropping it would break the runtime:
+  - **Cyclic subroutines** (self-recursion or mutual recursion). Static call-graph analysis (Tarjan's SCC) identifies subroutines participating in cycles; the hopper provides the forward-declaration needed for `call('foo')` to wrap something at the moment of construction. Mutual recursion `foo → bar → foo` continues to work.
+  - **Degenerate body `{ 1: stop }`**. The first-instruction "State" would be `haltState` itself; wrapping `haltState` produces an empty `symbolToDataMap` and the engine throws at runtime. Hopper provides a meaningful intermediate.
+  - **Leading group `[…]` or leading `call(...)`**. The first-instruction State is itself a wrapper; engine's nested-wohs collapse (#176) would unwrap the inner wrapping when the outer wrapper applies, losing the group's or inner call's continuation. Hopper preserves the chain.
+
+  Subroutines satisfying NONE of these — by far the common case — drop the hopper.
+
+  Observable changes:
+  - **Composite wrapper name**: `foo(continuation)` → `foo::1(continuation)` for hopper-dropped subs. Accurately reflects the bare's identity.
+  - **`summarizePostMachine().stateCount`**: −1 per hopper-dropped subroutine. The "Structural summary" README example shifts from `7 1 1` (alpha.2) to `6 1 1`.
+  - **`toMermaid` subgraph label**: `"callable subtree of foo"` → `"callable subtree of foo::1"` for hopper-dropped subs.
+  - **`onStep` callbacks per subroutine entry**: −1 iteration (the hopper used to fire its own `[*] → body₁` transition as a separate step; under #85, the wrapper-of-body₁ executes body₁'s transitions directly).
+
+### Migration from alpha.2
+
+**1. Wrapper composite name parser** — code that does `state.name.match(/^(\w+)\(/)` to extract the bare's name now sees `foo::1` for hopper-dropped subs (and still `foo` for hopper-retained ones). Use `state.bareStateId` (engine #174's GraphNode field) to identify the bare without parsing the name.
+
+**2. Test fixtures asserting `pm.initialState.name === 'foo(...)'`** — update to `'foo::1(...)'` for the hopper-dropped case. Or use a non-trivial body (multiple instructions) and assert on body-state names directly.
+
+**3. Test fixtures asserting exact `stateCount` or onStep call counts** — recompute under the new hopper-drop rules.
+
+**4. `pm.stateAt({ scope: ['foo'] })` or similar path lookups by subroutine name only** — under #85 there's no longer a graph node for the bare name in the hopper-dropped case. Lookups still resolve via the registry; behavior unchanged from a runtime perspective.
+
+### Out of v7-alpha.3 (still pending for stable v7.0.0)
+
+- **[#72](https://github.com/mellonis/post-machine-js/issues/72)** — extend `defineProperty` lockdown to intermediate engine-graph states.
+- **[#86](https://github.com/mellonis/post-machine-js/issues/86)** — user-supplied tags/labels on states (Mermaid + debugger surfaces).
+- **[#87](https://github.com/mellonis/post-machine-js/issues/87)** — README diagrams for `noop` and trailing-stop behaviors.
+
+### Compatibility
+
+- Engine peer dep unchanged: `^7.0.0-alpha.2`.
+
 ## [7.0.0-alpha.2] - 2026-05-21
 
 First post-machine-js v7 pre-release — adopts engine `@turing-machine-js/machine@7.0.0-alpha.2`. **post-machine-js skips its own v7 alpha.1**: engine alpha.1 was superseded by alpha.2 (which refined the `toMermaid` emit before any post-side adoption shipped), so post-machine-js's first v7 prerelease goes straight to alpha.2 matching the engine's current alpha. Published to npm under the `next` dist-tag: `npm install @post-machine-js/machine@next`.

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -471,10 +471,10 @@ console.log(a.stateCount, a.compositionEdgeCount, a.maxCompositionDepth);
 // 4 0 0 — inline: 4 states, no composition
 
 console.log(b.stateCount, b.compositionEdgeCount, b.maxCompositionDepth);
-// 7 1 1 — subroutine: 3 more states; 1 composition edge from `call` (depth 1)
+// 6 1 1 — subroutine: 2 more states; 1 composition edge from `call` (depth 1)
 ```
 
-Both programs do the same thing on the same input. This particular comparison is the **worst case for subroutines**: a single call site (no reuse benefit) with a small body — so the `withOverriddenHaltState` wrapper overhead per call (~3 states under engine v7's callable-subtree emit: a separate wrapper node, the hopper bare, and the continuation) shows up as pure cost. Subroutines start saving states when reuse is real and the body amortizes the wrapper overhead — see the [extend example](#subroutines) above for symmetric variants and the [duplicate-marked-region example](../../README.md#an-example-with-subroutines) in the root README for true multi-call.
+Both programs do the same thing on the same input. This particular comparison is the **worst case for subroutines**: a single call site (no reuse benefit) with a small body — so the `withOverriddenHaltState` wrapper overhead per call (~2 states under engine v7's callable-subtree emit + PostMachine's drop-acyclic-hopper rule from [#85](https://github.com/mellonis/post-machine-js/issues/85): the wrapper node and the continuation; the v6.x hopper is dropped for the common case of a plain leading command) shows up as pure cost. Subroutines start saving states when reuse is real and the body amortizes the wrapper overhead — see the [extend example](#subroutines) above for symmetric variants and the [duplicate-marked-region example](../../README.md#an-example-with-subroutines) in the root README for true multi-call.
 
 The two state graphs as the engine emits them — what the numbers above are summarizing:
 
@@ -507,34 +507,33 @@ flowchart TD
 flowchart TD
 %% alphabets: [[" ","*"]]
   s0(((halt)))
-  s7["10~20"]
-  s9["20"]
-  s8[["walkToBlank(10~20)"]]
+  s6["10~20"]
+  s8["20"]
+  s7[["walkToBlank::1(10~20)"]]
   idle([idle])
-  subgraph w_4["callable subtree of walkToBlank"]
-    s4["walkToBlank"]
-    s5["walkToBlank::1"]
-    s6["walkToBlank::2"]
+  subgraph w_4["callable subtree of walkToBlank::1"]
+    s4["walkToBlank::1"]
+    s5["walkToBlank::2"]
     c4(((halt)))
   end
-  idle -. enter .-> s8
-  s8 == "call" ==> s4
-  w_4 -. "return" .-> s8
-  s8 --> s7
-  s4 -- "[*] → [K]/[S]" --> s5
-  s5 -- "['*'] → [K]/[S]" --> s6
-  s5 -- "[B] → [K]/[S]" --> c4
-  s6 -- "[*] → [K]/[R]" --> s5
-  s7 -- "[*] → [K]/[S]" --> s9
-  s9 -- "[*] → ['*']/[S]" --> s0
+  idle -. enter .-> s7
+  s7 == "call" ==> s4
+  w_4 -. "return" .-> s7
+  s7 --> s6
+  s4 -- "['*'] → [K]/[S]" --> s5
+  s4 -- "[B] → [K]/[S]" --> c4
+  s5 -- "[*] → [K]/[R]" --> s4
+  s6 -- "[*] → [K]/[S]" --> s8
+  s8 -- "[*] → ['*']/[S]" --> s0
 ```
 
-The three extra nodes vs inline that drive `stateCount: 4 → 7`:
-- **`s8[["walkToBlank(10~20)"]]`** — the wrapper / call site, OUTSIDE the subgraph
-- **`s4["walkToBlank"]`** — the bare hopper INSIDE the callable subtree, forwarded to from the wrapper's bold `== "call" ==>` arrow
-- **`s7["10~20"]`** — the continuation that PostMachine synthesizes between the `call('walkToBlank')` site at instruction `10` and the next top-level instruction `20`
+The two extra nodes vs inline that drive `stateCount: 4 → 6`:
+- **`s7[["walkToBlank::1(10~20)"]]`** — the wrapper / call site, OUTSIDE the subgraph. Composite name `walkToBlank::1(10~20)` reflects that PostMachine drops the v6.x "hopper" anchor for acyclic subroutines with a plain first instruction (see [#85](https://github.com/mellonis/post-machine-js/issues/85)) — the wrapper wraps `walkToBlank::1` directly, saving one State.
+- **`s6["10~20"]`** — the continuation that PostMachine synthesizes between the `call('walkToBlank')` site at instruction `10` and the next top-level instruction `20`.
 
-The subroutine body (`s5`, `s6`) inside `subgraph w_4` mirrors `inline`'s `s1`, `s2` loop structurally — same algorithm, same internal back-edge. The extra cost is purely the wrapper machinery. `compositionEdgeCount: 0 → 1` and `maxCompositionDepth: 0 → 1` come from the single `withOverriddenHaltState` wrapper around `walkToBlank`.
+The subroutine body (`s4`, `s5`) inside `subgraph w_4` mirrors `inline`'s `s1`, `s2` loop structurally — same algorithm, same internal back-edge. The extra cost is purely the wrapper + continuation machinery. `compositionEdgeCount: 0 → 1` and `maxCompositionDepth: 0 → 1` come from the single `withOverriddenHaltState` wrapper.
+
+(Subroutines with `1: stop`, a leading `call(...)`, a leading group `[...]`, or that participate in a call-graph cycle keep the hopper as a forward-declaration anchor. The common case — plain leading command — drops it.)
 
 </details>
 

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@post-machine-js/machine",
-  "version": "7.0.0-alpha.2",
+  "version": "7.0.0-alpha.3",
   "description": "A convenient Post machine",
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/machine/src/callGraph.ts
+++ b/packages/machine/src/callGraph.ts
@@ -1,0 +1,248 @@
+// Static call-graph analysis for PostMachine subroutines (#85).
+//
+// At construction time, PostMachine creates a "hopper" State per subroutine —
+// a stub State that wraps a `Reference` to the subroutine's first instruction.
+// The hopper exists because `withOverriddenHaltState` needs a real State to
+// wrap, and at the moment `call('foo')` is invoked the subroutine's body may
+// not have been built yet (forward-reference / mutual-recursion case).
+//
+// For SUBROUTINES THAT DON'T PARTICIPATE IN CYCLES, the hopper is dead weight:
+// if we build callees before callers, the first-instruction State exists by
+// the time `call(...)` runs, and we can wrap it directly. The hopper-based
+// indirection only earns its keep when there's a true cycle that no build
+// order can break (a calls b, b calls a; or a calls a).
+//
+// This module identifies which local subroutines participate in cycles, so
+// the PostMachine constructor can:
+//   1. Create hoppers ONLY for cyclic subroutines.
+//   2. Process subroutines in a build order such that each acyclic
+//      subroutine's callees (in the same scope) are built before it.
+//
+// The analysis is per-scope: nested subroutines participate in their own
+// scope's analysis. A local sub calling an upper-scope sub is treated as a
+// leaf edge (upper-scope subs are built before the local scope is even
+// known, so they can't back-edge into local subs).
+
+import {callTargetOf} from './commands';
+import type {Instructions} from './commands';
+import type {CommandFn} from './consts';
+
+export type CallGraphAnalysis = {
+  /** Subroutines that participate in cycles (mutual recursion or self-loop). */
+  cyclicSet: Set<string>;
+  /**
+   * Build order — Tarjan's SCC output is in reverse topological order, so
+   * the first item is a sink (no outgoing dependencies on later items).
+   * Processing in this order ensures each acyclic subroutine's local callees
+   * are built before it.
+   */
+  buildOrder: string[];
+};
+
+/**
+ * Analyzes a set of local subroutines and returns:
+ *   - `cyclicSet`: subroutines that must keep their hopper (in non-trivial
+ *     SCC or with self-loop).
+ *   - `buildOrder`: order in which to recursively build them so that each
+ *     acyclic sub's callees are built first.
+ *
+ * Edges to subroutines NOT in `localSubroutines` (upper-scope) are leaf
+ * edges — they don't affect cycle detection locally.
+ */
+export function analyzeLocalCallGraph(
+  localSubroutines: Record<string, Instructions>,
+): CallGraphAnalysis {
+  const localNames = new Set(Object.keys(localSubroutines));
+
+  // Adjacency list: local-sub-name → set of LOCAL targets it calls.
+  const adj = new Map<string, Set<string>>();
+
+  for (const name of localNames) {
+    const allTargets = extractCallTargetsFromInstructions(localSubroutines[name]);
+    const localTargets = new Set([...allTargets].filter((t) => localNames.has(t)));
+
+    adj.set(name, localTargets);
+  }
+
+  // Tarjan's SCC algorithm. Outputs SCCs in reverse topological order — i.e.,
+  // the first SCC in the result is a sink with no outgoing dependencies on
+  // later SCCs. Process in this order for correct build order.
+  const sccs = tarjanSCC(adj, localNames);
+
+  const cyclicSet = new Set<string>();
+
+  for (const scc of sccs) {
+    const isMultiNode = scc.length > 1;
+
+    for (const member of scc) {
+      // `adj.get(member)` is always defined — every local name is keyed
+      // into `adj` in the loop above. The non-null assertion keeps the
+      // branch coverage at 100 without an unreachable `?? false` fallback.
+      const hasSelfLoop = adj.get(member)!.has(member);
+
+      if (isMultiNode || hasSelfLoop) {
+        cyclicSet.add(member);
+      }
+    }
+  }
+
+  // Build order is Tarjan's reverse-topological output flattened. Within an
+  // SCC, the order between members doesn't matter — all members are cyclic
+  // and use hoppers, so the build can proceed in any internal order.
+  const buildOrder: string[] = sccs.flatMap((scc) => scc);
+
+  return {cyclicSet, buildOrder};
+}
+
+// Same as `extractCallTargets` above but with the right return type. The
+// earlier function had a placeholder return; this is the real one.
+function extractCallTargetsFromInstructions(instructions: Instructions): Set<string> {
+  const targets = new Set<string>();
+
+  // Malformed inputs (null/undefined/non-object) are caught downstream by
+  // PostMachine's instruction validation. The analyzer just returns no edges
+  // for them so the caller can proceed to its own throw site.
+  if (instructions === null || typeof instructions !== 'object') {
+    return targets;
+  }
+
+  const visit = (value: unknown): void => {
+    if (typeof value === 'function') {
+      const target = callTargetOf(value as CommandFn);
+
+      if (target !== undefined) {
+        targets.add(target);
+      }
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        visit(item);
+      }
+    }
+  };
+
+  for (const key of Object.keys(instructions)) {
+    if (Number.isFinite(Number(key)) && key.trim() !== '') {
+      visit(instructions[key]);
+    }
+  }
+
+  return targets;
+}
+
+/**
+ * Tarjan's strongly-connected-components algorithm.
+ *
+ * Returns SCCs in REVERSE topological order — the first SCC has no outgoing
+ * edges to later SCCs, so it can be built first without forward references.
+ * Subsequent SCCs may depend on earlier ones.
+ *
+ * Iterative implementation to avoid recursion-depth issues on deep call
+ * chains (we never expect this to fire in practice but it's free defensive
+ * coverage).
+ */
+function tarjanSCC(
+  adj: Map<string, Set<string>>,
+  nodes: Set<string>,
+): string[][] {
+  const index = new Map<string, number>();
+  const lowlink = new Map<string, number>();
+  const onStack = new Set<string>();
+  const stack: string[] = [];
+  const sccs: string[][] = [];
+  let counter = 0;
+
+  // Iterative DFS frame: (node, iteratorOverNeighbors).
+  type Frame = {node: string; neighbors: Iterator<string>; pendingTarget: string | null};
+
+  const dfs = (start: string): void => {
+    const frames: Frame[] = [];
+
+    index.set(start, counter);
+    lowlink.set(start, counter);
+    counter += 1;
+    stack.push(start);
+    onStack.add(start);
+
+    // `adj.get(start)` is always defined — every `nodes` entry is keyed
+    // into `adj` by the caller before we start DFS.
+    frames.push({
+      node: start,
+      neighbors: adj.get(start)!.values(),
+      pendingTarget: null,
+    });
+
+    while (frames.length > 0) {
+      const frame = frames[frames.length - 1];
+
+      // If we just returned from a child DFS, fold its lowlink into ours.
+      if (frame.pendingTarget !== null) {
+        lowlink.set(
+          frame.node,
+          Math.min(lowlink.get(frame.node)!, lowlink.get(frame.pendingTarget)!),
+        );
+        frame.pendingTarget = null;
+      }
+
+      const {value: next, done} = frame.neighbors.next();
+
+      if (done) {
+        // All neighbors visited — emit SCC if this node is a root.
+        if (lowlink.get(frame.node) === index.get(frame.node)) {
+          const scc: string[] = [];
+
+          while (true) {
+            const popped = stack.pop()!;
+
+            onStack.delete(popped);
+            scc.push(popped);
+
+            if (popped === frame.node) break;
+          }
+
+          sccs.push(scc);
+        }
+
+        frames.pop();
+
+        // Tell parent which child we just returned from (for lowlink fold).
+        if (frames.length > 0) {
+          frames[frames.length - 1].pendingTarget = frame.node;
+        }
+
+        continue;
+      }
+
+      const target = next as string;
+
+      if (!index.has(target)) {
+        // Tree edge — descend.
+        index.set(target, counter);
+        lowlink.set(target, counter);
+        counter += 1;
+        stack.push(target);
+        onStack.add(target);
+
+        frames.push({
+          node: target,
+          neighbors: adj.get(target)!.values(),
+          pendingTarget: null,
+        });
+      } else if (onStack.has(target)) {
+        // Back edge to an ancestor in the current DFS tree.
+        lowlink.set(
+          frame.node,
+          Math.min(lowlink.get(frame.node)!, index.get(target)!),
+        );
+      }
+      // else: cross edge to a finished SCC — ignore.
+    }
+  };
+
+  for (const node of nodes) {
+    if (!index.has(node)) {
+      dfs(node);
+    }
+  }
+
+  return sccs;
+}

--- a/packages/machine/src/classes/PostMachine.ts
+++ b/packages/machine/src/classes/PostMachine.ts
@@ -23,6 +23,7 @@ import {
 } from '../commands';
 import { instructionIndexValidator, subroutineNameValidator, validateSymbolPair } from '../validators';
 import { installStateLockdown, withLockdownEscape } from '../lockdown';
+import { analyzeLocalCallGraph } from '../callGraph';
 import {
   type Breakpoint,
   type BreakpointFilter,
@@ -278,32 +279,98 @@ export class PostMachine extends TuringMachine {
       ...subroutinesDataFromUpperScope,
       ...localSubroutinesData,
     };
+    // Cycle-aware hopper construction (#85).
+    //
+    // Static analysis of the local subroutine call graph identifies which
+    // subroutines participate in cycles (mutual recursion or self-loop). For
+    // those, we keep the v6.x hopper — a stub `State` that wraps a
+    // `Reference` to the subroutine's first instruction, providing the
+    // forward-declaration anchor that `withOverriddenHaltState` needs at the
+    // moment `call(...)` invocations are processed.
+    //
+    // Acyclic subroutines (the common case) skip the hopper. We process them
+    // in reverse-topological build order — sinks first — so by the time
+    // `call('X')` runs for an acyclic X, X's first-instruction State already
+    // exists and we wrap it directly. Net effect: -1 graph node per acyclic
+    // subroutine; the wrapper composite name becomes `X::1(continuation)`
+    // (accurately reflects the wrapped bare) instead of `X(continuation)`.
+    const localSubroutineInstructions: Record<string, Instructions> = Object.fromEntries(
+      Object.entries(localSubroutinesData).map(([name, data]) => [name, data.instructions]),
+    );
+    const {cyclicSet, buildOrder} = analyzeLocalCallGraph(localSubroutineInstructions);
+
     const subroutineInitialStates: Record<string, State> = {
       ...subroutineInitialStatesFromUpperScope,
-      ...Object.keys(localSubroutinesData).reduce<Record<string, State>>((result, subroutineName) => ({
-        ...result,
-        [subroutineName]: new State({
+    };
+
+    // Create hoppers only for cyclic local subs. Acyclic entries are filled
+    // in after each acyclic sub's body is recursively built (below).
+    for (const subroutineName of Object.keys(localSubroutinesData)) {
+      if (cyclicSet.has(subroutineName)) {
+        subroutineInitialStates[subroutineName] = new State({
           [ifOtherSymbol]: {
             nextState: localSubroutinesData[subroutineName].reference,
           },
-        }, `${instructionPrefix}${subroutineName}`),
-      }), {}),
-    };
+        }, `${instructionPrefix}${subroutineName}`);
+      }
+    }
 
-    Object.keys(localSubroutinesData).forEach((subroutineName) => {
+    // Build subroutines in reverse-topological order. Tarjan's SCC output
+    // (in `buildOrder`) starts with sinks — local subs with no outgoing
+    // calls to other local subs — so each sub's local callees are built (and
+    // present in `subroutineInitialStates`) before the sub itself is built.
+    for (const subroutineName of buildOrder) {
       const {
         reference,
         instructions: subroutineInstructions,
       } = subroutinesData[subroutineName];
 
-      reference.bind(this.#buildInitialState({
+      const firstInstructionState = this.#buildInitialState({
         instructions: subroutineInstructions,
         subroutinesDataFromUpperScope: subroutinesData,
         subroutineInitialStatesFromUpperScope: subroutineInitialStates,
         instructionPrefix: `${instructionPrefix}${subroutineName}::`,
         scope: [...scope, subroutineName],
-      }));
-    });
+      });
+
+      reference.bind(firstInstructionState);
+
+      // Acyclic — install the first-instruction State as the subroutine's
+      // entry point IF it's safe to wrap. Two cases force a hopper fallback:
+      //
+      //   1. `firstInstructionState === haltState` (degenerate `{ 1: stop }`
+      //      body). Wrapping haltState produces a State with an empty
+      //      `symbolToDataMap`; the engine throws at runtime trying to
+      //      resolve a transition.
+      //
+      //   2. `firstInstructionState` is itself a wrapper (group `[…]` or
+      //      `call('bar')` as the subroutine's first instruction). Engine
+      //      #176 collapses nested `withOverriddenHaltState` chains — the
+      //      inner wrapping (group's own continuation, or the inner `call`'s
+      //      continuation) gets unwrapped and lost when this wrapper is
+      //      applied. Subsequent body instructions become unreachable.
+      //
+      // Both cases are detected by checking whether the first-instruction
+      // State is a plain bare (non-halt, no override). When it isn't, the
+      // hopper restores the invariant — it's a fresh State whose single
+      // `[ifOtherSymbol]` transition points at the first-instruction State,
+      // and wrapping the hopper preserves both the call-site continuation
+      // and any inner wrapping the first instruction already has.
+      if (!cyclicSet.has(subroutineName)) {
+        const canDropHopper = !firstInstructionState.isHalt
+          && firstInstructionState.overriddenHaltState === null;
+
+        if (canDropHopper) {
+          subroutineInitialStates[subroutineName] = firstInstructionState;
+        } else {
+          subroutineInitialStates[subroutineName] = new State({
+            [ifOtherSymbol]: {
+              nextState: firstInstructionState,
+            },
+          }, `${instructionPrefix}${subroutineName}`);
+        }
+      }
+    }
 
     const instructionIndexList = Object.keys(instructionsCopy);
 

--- a/packages/machine/src/commands.ts
+++ b/packages/machine/src/commands.ts
@@ -242,6 +242,20 @@ function stopCommandStateProducer(this: null, { calledFromGroup }: CommandContex
   return haltState;
 }
 
+// WeakMap from `call('foo')`-produced state-producers to the subroutine name
+// they reference. Used by the call-graph analyzer (#85 cycle detection — see
+// `callGraph.ts`) to read each producer's target without invoking it.
+const callTargets = new WeakMap<CommandFn, string>();
+
+/**
+ * Returns the subroutine name a `call(...)` producer targets, or `undefined`
+ * if the argument isn't a `call()` producer. Used at construction time to
+ * statically analyze which subroutines participate in cycles.
+ */
+export function callTargetOf(producer: CommandFn): string | undefined {
+  return callTargets.get(producer);
+}
+
 export function call(subroutineName: string, nextInstructionIndex?: number): (context: CommandContext) => State {
   const actualNextInstructionIndex = arguments.length === 1 ? defaultNextInstructionIndex : nextInstructionIndex;
 
@@ -251,6 +265,7 @@ export function call(subroutineName: string, nextInstructionIndex?: number): (co
   });
 
   commandsSet.add(actualCommand as CommandFn);
+  callTargets.set(actualCommand as CommandFn, subroutineName);
 
   return actualCommand as (context: CommandContext) => State;
 }

--- a/packages/machine/test/callGraph.spec.ts
+++ b/packages/machine/test/callGraph.spec.ts
@@ -1,0 +1,137 @@
+import {describe, expect, test} from 'vitest';
+
+import {analyzeLocalCallGraph} from '../src/callGraph';
+import {call, mark, stop} from '../src/commands';
+
+// Direct unit tests for the call-graph analyzer (#85). The full PostMachine
+// integration tests (`machine.spec.ts`, `naming.spec.ts`, `examples.spec.ts`)
+// exercise the analyzer indirectly through `new PostMachine(...)`, but those
+// fixtures rarely hit the cyclic-SCC paths. These tests poke the algorithm
+// directly to keep branch coverage at the repo's hard floor (100).
+
+describe('analyzeLocalCallGraph', () => {
+  test('empty input → no cyclic subs, no build order', () => {
+    const {cyclicSet, buildOrder} = analyzeLocalCallGraph({});
+
+    expect(cyclicSet.size).toBe(0);
+    expect(buildOrder).toEqual([]);
+  });
+
+  test('acyclic chain a → b → c → halt', () => {
+    const {cyclicSet, buildOrder} = analyzeLocalCallGraph({
+      a: {1: call('b'), 2: stop},
+      b: {1: call('c'), 2: stop},
+      c: {1: mark},
+    });
+
+    expect(cyclicSet.size).toBe(0);
+    // Build order is reverse-topological: sinks first. So c (no outgoing
+    // local calls) appears before b, and b before a.
+    expect(buildOrder.indexOf('c')).toBeLessThan(buildOrder.indexOf('b'));
+    expect(buildOrder.indexOf('b')).toBeLessThan(buildOrder.indexOf('a'));
+  });
+
+  test('mutual recursion a ↔ b — both marked cyclic', () => {
+    const {cyclicSet, buildOrder} = analyzeLocalCallGraph({
+      a: {1: call('b'), 2: stop},
+      b: {1: call('a'), 2: stop},
+    });
+
+    expect(cyclicSet.has('a')).toBe(true);
+    expect(cyclicSet.has('b')).toBe(true);
+    expect(buildOrder).toContain('a');
+    expect(buildOrder).toContain('b');
+  });
+
+  test('self-recursion a → a — marked cyclic', () => {
+    const {cyclicSet} = analyzeLocalCallGraph({
+      a: {1: call('a'), 2: stop},
+    });
+
+    expect(cyclicSet.has('a')).toBe(true);
+  });
+
+  test('mixed: acyclic leaf + cyclic pair', () => {
+    const {cyclicSet} = analyzeLocalCallGraph({
+      a: {1: call('b'), 2: call('leaf'), 3: stop},
+      b: {1: call('a'), 2: stop},
+      leaf: {1: mark},
+    });
+
+    expect(cyclicSet.has('a')).toBe(true);
+    expect(cyclicSet.has('b')).toBe(true);
+    expect(cyclicSet.has('leaf')).toBe(false);
+  });
+
+  test('edges to non-local subs are leaf edges (no cycle detected)', () => {
+    // 'a' calls 'external' which isn't in the local map. The analyzer treats
+    // external as a leaf — no edge contributes to local cycle detection.
+    const {cyclicSet} = analyzeLocalCallGraph({
+      a: {1: call('external'), 2: stop},
+    });
+
+    expect(cyclicSet.size).toBe(0);
+  });
+
+  test('handles null instruction bodies without throwing', () => {
+    // PostMachine's downstream validation catches malformed inputs; the
+    // analyzer must not throw on them.
+    expect(() => analyzeLocalCallGraph({a: null as never})).not.toThrow();
+
+    const {cyclicSet} = analyzeLocalCallGraph({a: null as never});
+
+    expect(cyclicSet.size).toBe(0);
+  });
+
+  test('calls inside groups are also extracted', () => {
+    // `call` inside a group throws at PostMachine construction (per the
+    // group rules), but the analyzer is tolerant and walks group arrays so
+    // it can still classify malformed-but-syntactically-parsed inputs.
+    const {cyclicSet} = analyzeLocalCallGraph({
+      a: {1: [mark, call('a')] as never, 2: stop},
+    });
+
+    expect(cyclicSet.has('a')).toBe(true);
+  });
+
+  test('3-node cycle a → b → c → a', () => {
+    // Exercises the SCC algorithm's multi-element scc emit path.
+    const {cyclicSet, buildOrder} = analyzeLocalCallGraph({
+      a: {1: call('b'), 2: stop},
+      b: {1: call('c'), 2: stop},
+      c: {1: call('a'), 2: stop},
+    });
+
+    expect(cyclicSet.has('a')).toBe(true);
+    expect(cyclicSet.has('b')).toBe(true);
+    expect(cyclicSet.has('c')).toBe(true);
+    // All three end up in the same SCC (consecutive in build order).
+    expect(buildOrder.length).toBe(3);
+  });
+
+  test('non-function non-array number-keyed values are ignored', () => {
+    // Defensive: a string under a number key isn't a command. PostMachine's
+    // constructor catches this downstream; the analyzer just walks past it
+    // without contributing any edges.
+    const {cyclicSet} = analyzeLocalCallGraph({
+      a: {1: 'not a command' as never, 2: stop},
+    });
+
+    expect(cyclicSet.size).toBe(0);
+  });
+
+  test('cross edges (target already in a finished SCC) are ignored', () => {
+    // Graph: a→b, a→c, b→c. DFS from a visits b first (pushes), b→c (pushes
+    // c, c has no outgoing, c is its own SCC, pop). Back to b, b's SCC pops.
+    // Back to a, a→c: c is already indexed AND not on the stack → cross
+    // edge to a finished SCC. The analyzer ignores it. None of these are
+    // cycles, so cyclicSet stays empty.
+    const {cyclicSet} = analyzeLocalCallGraph({
+      a: {1: call('b'), 2: call('c'), 3: stop},
+      b: {1: call('c'), 2: stop},
+      c: {1: mark},
+    });
+
+    expect(cyclicSet.size).toBe(0);
+  });
+});

--- a/packages/machine/test/examples.spec.ts
+++ b/packages/machine/test/examples.spec.ts
@@ -146,15 +146,17 @@ describe('packages/machine/README.md', () => {
       expect(mermaid).toContain('flowchart TD');
       expect(mermaid).toContain('%% alphabets: [[" ","*"]]');
 
-      // Halt + the entry — under engine v7's callable-subtree emit (alpha.2,
-      // #174) the wrapper is a separate `[[composite-name]]` node OUTSIDE the
-      // subgraph; the bare hopper is a regular `[name]` node INSIDE its
-      // callable subtree subgraph. Composite name `"rightToBlank(1~2)"` lives
-      // on the wrapper.
+      // Halt + the entry — under engine v7's callable-subtree emit (#174)
+      // PLUS PostMachine's drop-acyclic-hopper change (#85), the wrapper at
+      // the call site wraps `rightToBlank::1` directly (not the v6.x hopper
+      // named `rightToBlank`). The subgraph label and composite name both
+      // reflect the bare's identity.
       expect(mermaid).toContain('(((halt)))');
-      expect(mermaid).toMatch(/subgraph w_\d+\["callable subtree of rightToBlank"\]/);
-      expect(mermaid).toContain('[["rightToBlank(1~2)"]]');
-      expect(mermaid).toContain('["rightToBlank"]'); // bare inside the subgraph
+      expect(mermaid).toMatch(/subgraph w_\d+\["callable subtree of rightToBlank::1"\]/);
+      expect(mermaid).toContain('[["rightToBlank::1(1~2)"]]');
+      expect(mermaid).toContain('["rightToBlank::1"]'); // bare inside the subgraph
+      // The v6.x hopper named 'rightToBlank' is dropped (acyclic + plain first instr).
+      expect(mermaid).not.toContain('["rightToBlank"]');
 
       // Bold `== "call" ==>` from wrapper to bare + dotted `-. "return" .->`
       // from subgraph back to wrapper. The retired alpha.1 `-. onHalt .->`
@@ -383,11 +385,13 @@ describe('packages/machine/README.md', () => {
         expect(a.compositionEdgeCount).toBe(0);
         expect(a.maxCompositionDepth).toBe(0);
 
-        // Engine alpha.2 (#174) emits wrappers as separate nodes from their
-        // bares; the subroutine adds 1 wrapper node on top of the bare hopper +
-        // body states + continuation + top-level mark.
-        // console.log(b.stateCount, b.compositionEdgeCount, b.maxCompositionDepth); // 7 1 1
-        expect(b.stateCount).toBe(7);
+        // Under #85, `walkToBlank` is acyclic + has a plain first instruction
+        // (check), so its hopper is dropped. The subroutine contributes 2
+        // body states (walkToBlank::1, walkToBlank::2) + 1 continuation +
+        // the wrapper at instruction 10 + the top-level mark = 6 nodes
+        // (vs alpha.2's 7 with the hopper).
+        // console.log(b.stateCount, b.compositionEdgeCount, b.maxCompositionDepth); // 6 1 1
+        expect(b.stateCount).toBe(6);
         expect(b.compositionEdgeCount).toBe(1);
         expect(b.maxCompositionDepth).toBe(1);
 
@@ -407,9 +411,12 @@ describe('packages/machine/README.md', () => {
         expect(inlineMermaid).toMatch(/idle -\. enter \.-> s\d+/);
 
         // withSubroutine: wrapper outside the subgraph + callable-subtree shape.
-        expect(subMermaid).toMatch(/subgraph w_\d+\["callable subtree of walkToBlank"\]/);
-        expect(subMermaid).toContain('[["walkToBlank(10~20)"]]'); // wrapper, composite name
-        expect(subMermaid).toContain('["walkToBlank"]');          // bare, inside subgraph
+        // Under #85 the hopper is dropped — the wrapper wraps walkToBlank::1
+        // directly, not a bare named 'walkToBlank'.
+        expect(subMermaid).toMatch(/subgraph w_\d+\["callable subtree of walkToBlank::1"\]/);
+        expect(subMermaid).toContain('[["walkToBlank::1(10~20)"]]'); // wrapper composite
+        expect(subMermaid).toContain('["walkToBlank::1"]');          // bare, inside subgraph
+        expect(subMermaid).not.toContain('["walkToBlank"]');         // hopper dropped
         expect(subMermaid).toContain('["10~20"]');                // continuation
         expect(subMermaid).toMatch(/s\d+ == "call" ==> s\d+/);    // wrapper → bare
         expect(subMermaid).toMatch(/w_\d+ -\. "return" \.-> s\d+/);

--- a/packages/machine/test/machine-state.spec.ts
+++ b/packages/machine/test/machine-state.spec.ts
@@ -68,16 +68,21 @@ describe('PostMachine — wrapped MachineState', () => {
   });
 
   test('subroutine body instruction has fully-qualified arrivalPath', async () => {
+    // Use a 2-instruction body so the second instruction is visited as its
+    // own iter (the first instruction's State is now the wrapper's bare
+    // under #85 — its arrivalPath is the call site, not the FQ subroutine
+    // path. The second body instruction always gets its own iter regardless
+    // of hopper-drop status).
     const m = new PostMachine({
       10: call('foo'),
-      foo: { 1: mark },
+      foo: { 1: right, 2: mark },
     });
     const seen: MachineState[] = [];
     await m.run({ onStep: (s) => { seen.push(s); } });
-    // After the call wrapper, control reaches foo::1.
+    // After the call wrapper executes foo::1, control reaches foo::2.
     const fooStep = seen.find(s => {
       const scope = s.arrivalPath.scope;
-      return Array.isArray(scope) && scope.join('::') === 'foo' && s.arrivalPath.instructionIndex === 1;
+      return Array.isArray(scope) && scope.join('::') === 'foo' && s.arrivalPath.instructionIndex === 2;
     });
     expect(fooStep).toBeDefined();
   });

--- a/packages/machine/test/machine.spec.ts
+++ b/packages/machine/test/machine.spec.ts
@@ -450,9 +450,15 @@ describe('run tests', () => {
         stepsLimit: 3,
         onStep: (...args) => onStepMock3(...args),
       })).resolves.toBeUndefined();
-      expect(onStepMock1).toHaveBeenCalledTimes(3);
-      expect(onStepMock2).toHaveBeenCalledTimes(3);
-      expect(onStepMock3).toHaveBeenCalledTimes(3);
+      // Under #85, the subroutine's hopper is dropped (acyclic + plain first
+      // instruction noop). The previous "iter 1: hopper, iter 2: noop body,
+      // iter 3: halt" sequence collapses to "iter 1: wrapper-of-noop, iter 2:
+      // halt" — one fewer onStep call per machine. (Note: post-iter halt
+      // dispatches as the second call here because the wrapper-of-noop's
+      // halt-bound transition resolves to haltState directly.)
+      expect(onStepMock1).toHaveBeenCalledTimes(2);
+      expect(onStepMock2).toHaveBeenCalledTimes(2);
+      expect(onStepMock3).toHaveBeenCalledTimes(2);
       expect(onStepMock1.mock.calls).toEqual(onStepMock2.mock.calls);
       expect(onStepMock2.mock.calls).toEqual(onStepMock3.mock.calls);
     });
@@ -564,7 +570,14 @@ describe('run tests', () => {
       onStep: (...args) => onStepMock(...args),
     })).resolves.toBeUndefined();
 
-    expect(onStepMock).toHaveBeenCalledTimes(8);
+    // Under #85, hoppers are dropped for `subroutineNameList[1]` (outer,
+    // first instr `mark`, acyclic) and the nested `subroutineNameList[0]`
+    // (first instr `erase`, acyclic). Outer `subroutineNameList[0]` keeps
+    // its hopper (the analyzer sees its body calling 'sub0' as a lexical
+    // self-reference, conservatively classifying it as cyclic — runtime
+    // would resolve through shadowing, but the static analyzer doesn't
+    // model scope shadowing). Net: 2 fewer onStep calls than v6.x's 8.
+    expect(onStepMock).toHaveBeenCalledTimes(6);
     expect(machine.tape.viewport[0]).toEqual(' ');
 
     const nextSymbolHistory = onStepMock.mock.calls.map((aCall) => aCall[0].nextSymbols[0]);

--- a/packages/machine/test/naming.spec.ts
+++ b/packages/machine/test/naming.spec.ts
@@ -129,20 +129,23 @@ describe('PostMachine — subroutine body and hopper names', () => {
         3: mark,
       },
     });
-    // Wrapper composite at top — hopper now named "foo".
-    expect(machine.initialState.name).toBe('foo(10~halt)');
+    // Acyclic subroutine + plain first instruction → hopper dropped (#85).
+    // The wrapper's bare is foo's first-instruction State (foo::1) directly;
+    // composite name reflects that.
+    expect(machine.initialState.name).toBe('foo::1(10~halt)');
 
     // Subroutine body instructions are fully-qualified.
     const names = collectNames(machine);
     expect(names.has('foo::1')).toBe(true);
     expect(names.has('foo::2')).toBe(true);
     expect(names.has('foo::3')).toBe(true);
+    // Hopper dropped — no bare 'foo' node in the graph.
+    expect(names.has('foo')).toBe(false);
   });
 
-  test('nested subroutines use fully-qualified hopper names', () => {
-    // outer::1 is a call (produces a wrapper composite, not a plain "outer::1" node);
-    // outer::2 is mark (produces a real state named "outer::2").
-    // inner::1 is mark (produces a real state named "outer::inner::1").
+  test('nested subroutines use fully-qualified instruction names', () => {
+    // outer::1 is a call (the inner call wraps a wrapper, so outer keeps its
+    // hopper); outer::2 is a plain mark; inner::1 is a plain mark.
     const machine = new PostMachine({
       10: call('outer'),
       outer: {
@@ -151,17 +154,21 @@ describe('PostMachine — subroutine body and hopper names', () => {
         inner: { 1: mark },
       },
     });
-    // Top wrapper composite uses the top-level hopper name "outer".
+    // outer's first instruction is `call('inner')` — that produces a wrapper,
+    // so #85's hopper-drop is blocked (engine #176 would unwrap the inner
+    // wrapping). outer keeps its hopper named "outer".
     expect(machine.initialState.name).toBe('outer(10~halt)');
 
     const names = collectNames(machine);
-    // The nested call wrapper appears as bare 'outer::inner' (fq hopper) under v7's
-    // flatter emit; composite 'outer::inner(outer::1~outer::2)' lives only on state.name.
-    expect(names.has('outer::inner')).toBe(true);
+    // inner is acyclic with a plain first instruction (mark) → hopper dropped.
+    // No bare 'outer::inner' node; the inner-call wrapper composite is
+    // 'outer::inner::1(outer::1~outer::2)' and inner's body states have FQ names.
+    expect(names.has('outer::inner')).toBe(false);
+    expect(names.has('outer::inner::1')).toBe(true);
     // outer::2 is a plain mark instruction — it has its own named state.
     expect(names.has('outer::2')).toBe(true);
-    // Body states of inner subroutine are fully-qualified.
-    expect(names.has('outer::inner::1')).toBe(true);
+    // outer keeps its hopper (acyclic but first instr is a wrapper).
+    expect(names.has('outer')).toBe(true);
   });
 });
 
@@ -176,12 +183,14 @@ describe('PostMachine — combined naming scenarios', () => {
       },
     });
     const names = collectNames(machine);
-    // Under v7, the wrapper inside foo for call('bar') appears as bare 'foo::bar'
-    // (fq-prefixed nested hopper) with a separate continuation 'foo::1~foo::2'.
-    expect(names.has('foo::bar')).toBe(true);
+    // Under #85, `bar` is acyclic + plain first instruction (mark) → hopper
+    // dropped; no bare 'foo::bar' node. The inner-call wrapper composite is
+    // 'foo::bar::1(foo::1~foo::2)' on state.name, with body state 'foo::bar::1'
+    // appearing as a node.
+    expect(names.has('foo::bar')).toBe(false);
+    expect(names.has('foo::bar::1')).toBe(true);
     expect(names.has('foo::1~foo::2')).toBe(true);
     expect(names.has('foo::2')).toBe(true);
-    expect(names.has('foo::bar::1')).toBe(true);
   });
 
   test('group inside subroutine — inner indices namespaced', () => {
@@ -210,9 +219,10 @@ describe('PostMachine — combined naming scenarios', () => {
       },
     });
     const names = collectNames(machine);
-    // Wrapper at foo::1 appears as bare 'foo::bar' under v7; composite
-    // 'foo::bar(foo::1~halt)' (tail position inside foo) lives only on state.name.
-    expect(names.has('foo::bar')).toBe(true);
+    // Under #85, `bar` is acyclic + plain first instruction → hopper dropped.
+    // No bare 'foo::bar' node; the bare 'foo::bar::1' is the wrapper's target,
+    // and the tail-position continuation is 'foo::1~halt'.
+    expect(names.has('foo::bar')).toBe(false);
     expect(names.has('foo::1~halt')).toBe(true);
     expect(names.has('foo::bar::1')).toBe(true);
   });
@@ -230,10 +240,10 @@ describe('PostMachine — combined naming scenarios', () => {
       },
     });
     const names = collectNames(machine);
-    // Each scope hops accumulate in the prefix.
+    // Each scope hops accumulate in the prefix. `deepest` is acyclic with a
+    // plain first instruction → hopper dropped (#85); only its body state
+    // 'outer::inner::deepest::1' appears in the graph.
     expect(names.has('outer::inner::deepest::1')).toBe(true);
-    // Body inner at outer::inner::1 calls deepest. Under v7, the wrapper appears as
-    // bare 'outer::inner::deepest' (the fq hopper) with separate continuation.
-    expect(names.has('outer::inner::deepest')).toBe(true);
+    expect(names.has('outer::inner::deepest')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes #85.

PostMachine used to create a "hopper" State per subroutine (named `foo`, with a single `[ifOtherSymbol] → reference` transition to the subroutine's first body instruction). The hopper exists as a forward-declaration anchor for `withOverriddenHaltState` — \`call('foo')\` wraps the hopper at construction-time before \`foo\`'s body is built.

For the common case, the hopper is dead weight: if we build callees before callers (per a static call-graph analysis), the first-instruction State already exists when \`call('foo')\` runs and can be wrapped directly. The wrapper composite name then accurately reflects the wrapped bare.

## Static call-graph analysis

New module \`src/callGraph.ts\` runs Tarjan's SCC over the local subroutine call graph (per scope). Returns:
- \`cyclicSet\` — subroutines participating in non-trivial SCCs OR with a self-loop edge.
- \`buildOrder\` — reverse-topological order; sinks first so each sub's local callees are already built when the sub itself is processed.

## When the hopper is retained

| Case | Why |
|---|---|
| Cyclic subroutine | Forward-declaration needed; can't resolve `bar::1` while `bar`'s body is mid-build during a `foo→bar→foo` cycle |
| Degenerate body `{ 1: stop }` | First-instruction State is `haltState` directly. Wrapping `haltState` produces a State with empty `symbolToDataMap` → engine throws at runtime |
| Leading group `[...]` | First-instruction State is a group wrapper. Engine #176's nested-wohs collapse would unwrap it, losing the group's continuation chain |
| Leading `call(...)` | Same: first-instruction State is a call wrapper. Inner call's continuation would be lost |

Common case (acyclic + plain leading command like \`right\`/\`mark\`/\`check\`/\`erase\`): hopper dropped.

## Mutual recursion still supported

Verified by probe — \`{ foo: {1: call('bar'), 2: stop}, bar: {1: call('foo'), 2: stop}, 1: call('foo'), 2: stop }\` constructs and runs as before. Both \`foo\` and \`bar\` are in the cyclicSet → both keep hoppers.

## Observable changes

For hopper-dropped subroutines:
- Composite wrapper name: \`foo(continuation)\` → \`foo::1(continuation)\`
- \`summarizePostMachine().stateCount\`: −1 per call site
- \`toMermaid\` subgraph label: \`"callable subtree of foo"\` → \`"callable subtree of foo::1"\`
- \`onStep\` callbacks per subroutine entry: −1 iter

Full migration walkthrough in the CHANGELOG entry.

## Verification

- [x] \`npm test\` — 276/276 pass (267 prior + 9 new in callGraph.spec.ts)
- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm run test:coverage\` — **100/100/100/100** (above the hard floor)
- [x] \`npm publish --dry-run --tag next\` — clean, would publish \`@post-machine-js/machine@7.0.0-alpha.3\` under \`next\`

## After-merge steps

1. \`npx lerna publish from-package --dist-tag next --yes\` from \`v7\` head.
2. \`gh release create v7.0.0-alpha.3 --prerelease --target v7 --title v7.0.0-alpha.3 --notes-file <changelog excerpt>\`.

## Out of scope (filed separately)

- [#86](https://github.com/mellonis/post-machine-js/issues/86) — user-supplied tags/labels on states (surfaced from this work; tracked separately).
- [#87](https://github.com/mellonis/post-machine-js/issues/87) — README diagrams for `noop` and trailing-stop behaviors.

Next branch will adopt the engine repo's co-located spec-file convention (\`*.spec.ts\` next to source instead of in \`test/\`) — separate PR per agreement.