### PR TITLE
docs(README): add diagrams for noop and trailing-stop behaviors (#87)

### DIFF
--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -177,6 +177,83 @@ The first table is the **canonical instruction set** of a Post(–Turing) machin
 
 `call` and the [Subroutines](#subroutines) feature add procedure-like reuse to the classical numbered-instruction model. `noop` is the placeholder of choice: useful for reserving instruction numbers in a worked example, padding a sketch, or as a labelled jump target. (Bare `noop` has no classical analog; `noop(ix)` corresponds to Post's unconditional jump.)
 
+<details>
+<summary><code>noop</code> in the graph — fall-through and unconditional jump</summary>
+
+```javascript
+const machine = new PostMachine({
+  10: mark,
+  20: noop,
+  30: mark,
+  40: stop,
+});
+```
+
+```mermaid
+flowchart TD
+%% alphabets: [[" ","*"]]
+  s0(((halt)))
+  s1["10"]
+  s2["20"]
+  s3["30"]
+  idle([idle])
+  idle -. enter .-> s1
+  s1 -- "[*] → ['*']/[S]" --> s2
+  s2 -- "[*] → [K]/[S]" --> s3
+  s3 -- "[*] → ['*']/[S]" --> s0
+```
+
+`s2` is the noop. Its single outgoing edge `[*] → [K]/[S]` is the signature: read anything, keep the cell (`K`, no write), stay in place (`S`, no move) — then fall through to instruction 30. The marks at `s1` and `s3` write `'*'` and move stay; the structural difference between a "useful" command and `noop` is the write cell (`'*'` vs `K`).
+
+Indexed form `noop(40)` rewires the fall-through to instruction 40 — Post's unconditional jump:
+
+```javascript
+const machine = new PostMachine({
+  10: noop(40),
+  20: mark,
+  30: mark,
+  40: stop,
+});
+```
+
+```mermaid
+flowchart TD
+%% alphabets: [[" ","*"]]
+  s0(((halt)))
+  s1["10"]
+  idle([idle])
+  idle -. enter .-> s1
+  s1 -- "[*] → [K]/[S]" --> s0
+```
+
+Instruction `10` jumps directly to `40` (the trailing stop). Instructions `20` and `30` are unreachable — they don't appear in the graph at all. (`toGraph` only emits reachable states; unreachable ones are silently dropped.)
+
+</details>
+
+<details>
+<summary>Trailing <code>stop</code> doesn't get its own node</summary>
+
+```javascript
+const machine = new PostMachine({
+  10: mark,
+  20: stop,
+});
+```
+
+```mermaid
+flowchart TD
+%% alphabets: [[" ","*"]]
+  s0(((halt)))
+  s1["10"]
+  idle([idle])
+  idle -. enter .-> s1
+  s1 -- "[*] → ['*']/[S]" --> s0
+```
+
+Notice: no `s20` node. `stop` halts the machine, so `s1` (`10: mark`) transitions directly to `s0(((halt)))` — there's no intermediate state for the `stop` instruction. The trailing `stop` is **elided** in the structural emit: it's a halt routing convention, not a State.
+
+The lookup API is asymmetric in a useful way — `pm.stateAt({ instructionIndex: 20 })` for this machine resolves to `haltState` (the canonical halt singleton), not `undefined`. The graph doesn't render `s20`, but the path still resolves.</details>
+
 ## Grouped instructions
 
 Several commands can share a single instruction number by passing them as an array:

--- a/packages/machine/src/classes/PostMachine.examples.spec.ts
+++ b/packages/machine/src/classes/PostMachine.examples.spec.ts
@@ -5,7 +5,7 @@ import {
   alphabet,
   blankSymbol,
   markSymbol,
-  call, check, left, mark, right, stop,
+  call, check, left, mark, noop, right, stop,
   toMermaid,
   summarizePostMachine,
   equivalentPostMachines,
@@ -58,6 +58,78 @@ describe('packages/machine/README.md', () => {
       // console.log(machine.tape.symbols.join('').trim()); // ***
       expect(machine.tape.symbols.join('').trim())
         .toBe('***');
+    });
+  });
+
+  describe('Commands', () => {
+    describe('noop in the graph — fall-through and unconditional jump', () => {
+      test('noop in a chain produces a single [K]/[S] state', () => {
+        const machine = new PostMachine({
+          10: mark,
+          20: noop,
+          30: mark,
+          40: stop,
+        });
+
+        const mermaid = toMermaid(State.toGraph(machine.initialState, machine.tapeBlock));
+
+        // 3 reachable instructions (`40: stop` is elided — see trailing-stop test below).
+        expect(mermaid).toContain('["10"]');
+        expect(mermaid).toContain('["20"]');
+        expect(mermaid).toContain('["30"]');
+        // noop's signature: `[K]/[S]` — keep, stay. Marks have `['*']/[S]`.
+        expect(mermaid).toMatch(/s\d+ -- "\[\*\] → \[K\]\/\[S\]" --> s\d+/); // noop
+        expect(mermaid).toMatch(/s\d+ -- "\[\*\] → \['\*'\]\/\[S\]" --> s\d+/); // mark
+      });
+
+      test('noop(40) jumps directly; unreachable instructions are dropped', () => {
+        const machine = new PostMachine({
+          10: noop(40),
+          20: mark,
+          30: mark,
+          40: stop,
+        });
+
+        const mermaid = toMermaid(State.toGraph(machine.initialState, machine.tapeBlock));
+
+        // Only instruction 10 appears; 20/30 are unreachable, 40 = trailing stop.
+        expect(mermaid).toContain('["10"]');
+        expect(mermaid).not.toContain('"20"');
+        expect(mermaid).not.toContain('"30"');
+        // 10's transition is noop's `[K]/[S]` straight to halt (s0).
+        expect(mermaid).toMatch(/s\d+ -- "\[\*\] → \[K\]\/\[S\]" --> s0/);
+      });
+    });
+
+    describe('Trailing stop doesn\'t get its own node', () => {
+      test('{ 10: mark, 20: stop } emits one state, not two', () => {
+        const machine = new PostMachine({
+          10: mark,
+          20: stop,
+        });
+
+        const mermaid = toMermaid(State.toGraph(machine.initialState, machine.tapeBlock));
+
+        expect(mermaid).toContain('["10"]');
+        // No "20" label — the trailing stop is elided as a halt routing
+        // convention; instruction 10 transitions straight to s0(((halt))).
+        expect(mermaid).not.toContain('"20"');
+        expect(mermaid).toMatch(/s\d+ -- "\[\*\] → \['\*'\]\/\[S\]" --> s0/);
+      });
+
+      test('pm.stateAt for a trailing-stop index resolves to haltState', () => {
+        const machine = new PostMachine({
+          10: mark,
+          20: stop,
+        });
+
+        const stopState = machine.stateAt({instructionIndex: 20});
+
+        // Graph doesn't render `s20`, but the lookup API still resolves the
+        // path to the canonical haltState singleton.
+        expect(stopState).toBeDefined();
+        expect(stopState!.isHalt).toBe(true);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #87.

Two PostMachine conventions previously had prose-only treatment in the README; this PR adds collapsed-by-default `<details>` blocks with real engine-emitted Mermaid + companion tests.

### Added under `## Commands`

#### 1. `noop` in the graph — fall-through + unconditional jump

Two sub-diagrams:

- **Fall-through chain** `{ 10: mark, 20: noop, 30: mark, 40: stop }` — three reachable states; noop's `[*] → [K]/[S]` signature (read anything, keep, stay) is the structural distinction from the surrounding marks' `[*] → ['*']/[S]`.
- **`noop(40)` as unconditional jump** — only the source instruction appears in the graph; intermediate unreachable instructions are silently dropped by `toGraph`.

#### 2. Trailing `stop` doesn't get its own node

`{ 10: mark, 20: stop }` emits ONE state — `stop` is a halt routing convention, not a State. Inline note covers the asymmetry that `pm.stateAt({ instructionIndex: 20 })` still resolves (to the canonical `haltState` singleton).

### Tests

Three new tests under a new `Commands` describe block in `packages/machine/src/classes/PostMachine.examples.spec.ts`, mirroring the README structure. Shape-based assertions (`toContain('["10"]')` + transition-label regex) — IDs aren't pinned since the global `State.#id` counter shifts across test ordering.

## Test plan

- [x] `npm test` — 282/282 pass (279 prior + 3 new)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test:coverage` — 100/100/100/100 (above the hard floor)

Pure docs + tests. No source change.