### PR TITLE
feat: state tags + auto-tag policy (#86)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.0-alpha.4",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.2"
+        "@turing-machine-js/machine": "^7.0.0-alpha.3"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.13",
@@ -2740,9 +2740,9 @@
       }
     },
     "node_modules/@turing-machine-js/machine": {
-      "version": "7.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.2.tgz",
-      "integrity": "sha512-mGtG/yXznBnBjiVP3TbW0TaEGsCKoYstJRopK+WL38pQabiEyLyOlvYZlVICfvKkeA6MLjkuVyE644QeSNf+YQ==",
+      "version": "7.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.3.tgz",
+      "integrity": "sha512-+5FW2WRikdcXM2o7qKVnWeMCFuOMIAySV01ATZoFiYlz9o797+MFxVjpSmJ3KQNqTijeXutIPlVdQl2a0VHhXA==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10441,16 +10441,16 @@
     },
     "packages/machine": {
       "name": "@post-machine-js/machine",
-      "version": "7.0.0-alpha.3",
+      "version": "7.0.0-alpha.4",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.2"
+        "@turing-machine-js/machine": "^7.0.0-alpha.3"
       },
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.2"
+        "@turing-machine-js/machine": "^7.0.0-alpha.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@turing-machine-js/machine": "^7.0.0-alpha.2"
+    "@turing-machine-js/machine": "^7.0.0-alpha.3"
   }
 }

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0-alpha.4] - 2026-05-21
+
+Fourth v7 pre-release. Adds user-supplied tags on states ([#86](https://github.com/mellonis/post-machine-js/issues/86)) — both an inline decorator at construction and a path-based registry post-construction — plus an auto-tag policy that marks each program's/subroutine's entry state. Engine peer-dep widened `^7.0.0-alpha.3` (the new `state.tag(...)` API was added by engine alpha.3). Published to npm under the `next` dist-tag: `npm install @post-machine-js/machine@next`.
+
+**Pre-release — the API surface may still shift before stable v7.0.0.** Pin to a specific alpha for reproducibility: `@post-machine-js/machine@7.0.0-alpha.4`.
+
+### Added
+
+- **`$tag(...tags, command)` inline decorator** ([#86](https://github.com/mellonis/post-machine-js/issues/86)). Wraps a command with one or more tags; tags apply to the resulting State via the engine's `state.tag(...)` API. The leading `$` flags it visually as a decorator (not a primitive command). Variadic — `$tag('hot', 'sampled', mark)` adds both tags. Rejects groups — `$tag('foo', [mark, right])` throws ("tag each member individually"). Rejects bare `$tag` (uninvoked) as an instruction with a message pointing at the correct form. Composes with indexed commands: `$tag('loop-head', check(20, 40))`, `$tag('subroutine-entry', call('foo'))`.
+
+- **Path-based tag registry on `PostMachine`** ([#86](https://github.com/mellonis/post-machine-js/issues/86)):
+  - `pm.tag(path, ...tags)` — add tags to the state at path
+  - `pm.untag(path, ...tags)` — remove tags (no-op if absent)
+  - `pm.tagsOf(path)` — frozen snapshot of the state's tags
+  - `pm.findByTag(tag)` — all paths whose state currently carries that tag
+
+  All four resolve `path` the same way as `pm.stateAt` (string `'10'` / `'sub::1'` or object `{ instructionIndex: 10 }`). Throws on an unknown path. PostMachine does not maintain its own tag storage — all four forward to the engine's `state.tag(...)` / `.untag(...)` / `.tags` API.
+
+- **Auto-tag policy at construction** ([#86](https://github.com/mellonis/post-machine-js/issues/86)). PostMachine auto-tags the **entry point** of each program/subroutine:
+  - Top-level entry (first numbered instruction) → tag `'main'`
+  - Subroutine entry (first instruction of each subroutine body) → tag matching the subroutine name (`'sub'`, `'rightToBlank'`, …)
+
+  Non-entry instructions and group inner states stay clean. Halt-resolving paths (`stop`-only entries) are skipped — `stop` resolves to the globally-shared engine `haltState` singleton, so tagging it would leak the tag across all PostMachine instances. Auto-tags compose with user tags; both accumulate on the same state.
+
+- **README `## Tags` section**. Documents `$tag`, the registry methods, the auto-tag policy, and the Mermaid output shape. Linked from the TOC and from the Subroutines section.
+
+### Changed
+
+- **README diagram outputs reflect auto-tag emit**. Existing example Mermaid blocks now show `<br>main` / `<br>rightToBlank` / `<br>walkToBlank` suffixes on entry-point node labels plus trailing `classDef tag_<name>` + `class sN tag_<name>` lines. The simple-subroutine `<details>` block was additionally rewritten to reflect the alpha.3 hopper-drop shape (`rightToBlank::1` bare + `rightToBlank::1(1~2)` composite wrapper) that had been left stale.
+
+### Compatibility
+
+- Engine peer dep unchanged: `^7.0.0-alpha.3` (already pinned at alpha.3 since the alpha.3 release; alpha.3's `state.tag(...)` / `.untag(...)` / `.tags` surface is what this release builds on).
+- **Mermaid output ships auto-tag annotations by default.** Consumers that pin to exact diagram strings need to update their fixtures. The annotations are deterministic per machine.
+
+### Out of v7-alpha.4 (still pending for stable v7.0.0)
+
+- **[#72](https://github.com/mellonis/post-machine-js/issues/72)** — extend `defineProperty` lockdown to intermediate engine-graph states.
+
 ## [7.0.0-alpha.3] - 2026-05-21
 
 Third v7 pre-release. Drops the v6.x subroutine "hopper" State for the common case where it's not needed for forward-declaration ([#85](https://github.com/mellonis/post-machine-js/issues/85)). Engine peer-dep unchanged (`^7.0.0-alpha.2`). Published to npm under the `next` dist-tag: `npm install @post-machine-js/machine@next`.

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -496,11 +496,13 @@ Three ways to apply tags: the **inline `$tag` decorator** at construction, the *
 
 `$tag(...tags, command)` wraps a command with one or more tags. The tags apply to the resulting State; no extra graph node is created. The leading `$` flags it visually as a decorator (not a primitive command).
 
+**Wrapping a single command.** The common case — one tag per state, applied per instruction:
+
 ```javascript
 import { PostMachine, $tag, check, mark, right, stop } from '@post-machine-js/machine';
 
 const machine = new PostMachine({
-  10: $tag('hot', check(20, 30)),         // tag a single state
+  10: $tag('hot', check(20, 30)),               // tag a single state
   20: $tag('loop-body', 'sampled', right(10)),  // variadic — many tags at once
   30: mark,
   40: stop,
@@ -510,7 +512,77 @@ console.log(machine.tagsOf({ instructionIndex: 10 }));
 // ['hot', 'main'] — inline 'hot' applied at producer time, then 'main' auto-tag
 ```
 
-`$tag` rejects groups — `$tag('foo', [mark, right])` throws at construction. Tag each member individually: `[$tag('lift', mark), $tag('descend', right)]`. Passing bare `$tag` (without invoking it) as an instruction also throws with a helpful message.
+```mermaid
+flowchart TD
+%% alphabets: [[" ","*"]]
+  s0(((halt)))
+  s1["10<br>hot, main"]
+  s2["20<br>loop-body, sampled"]
+  s3["30"]
+  idle([idle])
+  idle -. enter .-> s1
+  s1 -- "['*'] → [K]/[S]" --> s2
+  s1 -- "[B] → [K]/[S]" --> s3
+  s2 -- "[*] → [K]/[R]" --> s1
+  s3 -- "[*] → ['*']/[S]" --> s0
+  classDef tag_hot fill:#dbeafe,stroke:#1e40af
+  classDef tag_loop-body fill:#fee2e2,stroke:#991b1b
+  classDef tag_main fill:#dbeafe,stroke:#1e40af
+  classDef tag_sampled fill:#ede9fe,stroke:#5b21b6
+  class s1 tag_hot
+  class s2 tag_loop-body
+  class s1 tag_main
+  class s2 tag_sampled
+```
+
+`s1` carries two tags (`hot` from `$tag` + `main` from auto-tag) — the engine emits them comma-separated in the label and applies BOTH `classDef` lines via two `class s1 …` directives. Tag composition is additive.
+
+**Per-member in a group.** `$tag` rejects wrapping a group as a whole (`$tag('foo', [mark, right])` throws). Tag each member individually instead — the inner tags land on the per-member states inside the group's callable subtree:
+
+```javascript
+import { PostMachine, $tag, mark, right, stop } from '@post-machine-js/machine';
+
+const machine = new PostMachine({
+  10: [$tag('lift', mark), $tag('descend', right)],
+  20: stop,
+});
+
+console.log(machine.tagsOf({ instructionIndex: 10, groupInstructionIndex: 1 }));
+// ['lift']
+console.log(machine.tagsOf('10'));
+// ['main'] — the outer wrapper at path '10' carries the auto-tag for the top-level entry
+```
+
+```mermaid
+flowchart TD
+%% alphabets: [[" ","*"]]
+  s0(((halt)))
+  s6["10~20"]
+  s7[["10.1(10~20)<br>main"]]
+  idle([idle])
+  subgraph w_4["callable subtree of 10.1"]
+    s4["10.1<br>lift"]
+    s5["10.2<br>descend"]
+    c4(((halt)))
+  end
+  idle -. enter .-> s7
+  s7 == "call" ==> s4
+  w_4 -. "return" .-> s7
+  s7 --> s6
+  s4 -- "[*] → ['*']/[S]" --> s5
+  s5 -- "[*] → [K]/[R]" --> c4
+  s6 -- "[*] → [K]/[S]" --> s0
+  classDef tag_descend fill:#fef3c7,stroke:#92400e
+  classDef tag_lift fill:#fee2e2,stroke:#991b1b
+  classDef tag_main fill:#dbeafe,stroke:#1e40af
+  class s5 tag_descend
+  class s4 tag_lift
+  class s7 tag_main
+```
+
+The group expands into a `withOverriddenHaltState` chain wrapped in a callable subtree (same shape as a subroutine call). The wrapper `s7` is the top-level entry (auto-tagged `main`); the inner states `s4` (`lift`) and `s5` (`descend`) carry their per-member tags inside the subgraph. The group's outer path `'10'` resolves to the wrapper; group-inner paths use the `{ instructionIndex: 10, groupInstructionIndex: N }` shape.
+
+Passing bare `$tag` (without invoking it) as an instruction or as a group member also throws — with a message pointing at the correct form.
 
 ### Post-construction registry
 

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -18,6 +18,7 @@ A Post machine — a 2-symbol Turing-machine variant with a numbered-instruction
 - [Subroutines](#subroutines)
 - [MachineState shape](#machinestate-shape)
 - [Naming convention](#naming-convention)
+- [Tags](#tags) — [`$tag` decorator](#inline-tag-decorator) · [Registry](#post-construction-registry) · [Auto-tag policy](#auto-tag-policy) · [Mermaid output](#mermaid-output)
 - [Introspection and equivalence](#introspection-and-equivalence) — [Visualization](#visualization--tomermaid--statetograph) · [Structural summary](#structural-summary--summarizepostmachine) · [Behavioral equivalence](#behavioral-equivalence--equivalentpostmachines)
 - [Debugging](#debugging)
 - [Links](#links)
@@ -63,7 +64,7 @@ The state graph for the example above (`toMermaid(State.toGraph(machine.initialS
 flowchart TD
 %% alphabets: [[" ","*"]]
   s0(((halt)))
-  s1["10"]
+  s1["10<br>main"]
   s2["20"]
   s3["30"]
   idle([idle])
@@ -72,6 +73,8 @@ flowchart TD
   s1 -- "[B] → [K]/[S]" --> s3
   s2 -- "[*] → [K]/[R]" --> s1
   s3 -- "[*] → ['*']/[S]" --> s0
+  classDef tag_main fill:#dbeafe,stroke:#1e40af
+  class s1 tag_main
 ```
 
 Reading the diagram:
@@ -193,7 +196,7 @@ const machine = new PostMachine({
 flowchart TD
 %% alphabets: [[" ","*"]]
   s0(((halt)))
-  s1["10"]
+  s1["10<br>main"]
   s2["20"]
   s3["30"]
   idle([idle])
@@ -201,6 +204,8 @@ flowchart TD
   s1 -- "[*] → ['*']/[S]" --> s2
   s2 -- "[*] → [K]/[S]" --> s3
   s3 -- "[*] → ['*']/[S]" --> s0
+  classDef tag_main fill:#dbeafe,stroke:#1e40af
+  class s1 tag_main
 ```
 
 `s2` is the noop. Its single outgoing edge `[*] → [K]/[S]` is the signature: read anything, keep the cell (`K`, no write), stay in place (`S`, no move) — then fall through to instruction 30. The marks at `s1` and `s3` write `'*'` and move stay; the structural difference between a "useful" command and `noop` is the write cell (`'*'` vs `K`).
@@ -220,10 +225,12 @@ const machine = new PostMachine({
 flowchart TD
 %% alphabets: [[" ","*"]]
   s0(((halt)))
-  s1["10"]
+  s1["10<br>main"]
   idle([idle])
   idle -. enter .-> s1
   s1 -- "[*] → [K]/[S]" --> s0
+  classDef tag_main fill:#dbeafe,stroke:#1e40af
+  class s1 tag_main
 ```
 
 Instruction `10` jumps directly to `40` (the trailing stop). Instructions `20` and `30` are unreachable — they don't appear in the graph at all. (`toGraph` only emits reachable states; unreachable ones are silently dropped.)
@@ -244,10 +251,12 @@ const machine = new PostMachine({
 flowchart TD
 %% alphabets: [[" ","*"]]
   s0(((halt)))
-  s1["10"]
+  s1["10<br>main"]
   idle([idle])
   idle -. enter .-> s1
   s1 -- "[*] → ['*']/[S]" --> s0
+  classDef tag_main fill:#dbeafe,stroke:#1e40af
+  class s1 tag_main
 ```
 
 Notice: no `s20` node. `stop` halts the machine, so `s1` (`10: mark`) transitions directly to `s0(((halt)))` — there's no intermediate state for the `stop` instruction. The trailing `stop` is **elided** in the structural emit: it's a halt routing convention, not a State.
@@ -315,37 +324,40 @@ The state graph as the engine emits it — the subroutine and the wrapping `with
 flowchart TD
 %% alphabets: [[" ","*"]]
   s0(((halt)))
-  s4["1~2"]
-  s6["2"]
-  s5[["rightToBlank(1~2)"]]
+  s3["1~2"]
+  s5["2"]
+  s4[["rightToBlank::1(1~2)<br>main"]]
   idle([idle])
-  subgraph w_1["callable subtree of rightToBlank"]
-    s1["rightToBlank"]
-    s2["rightToBlank::1"]
-    s3["rightToBlank::2"]
+  subgraph w_1["callable subtree of rightToBlank::1"]
+    s1["rightToBlank::1<br>rightToBlank"]
+    s2["rightToBlank::2"]
     c1(((halt)))
   end
-  idle -. enter .-> s5
-  s5 == "call" ==> s1
-  w_1 -. "return" .-> s5
-  s5 --> s4
-  s1 -- "[*] → [K]/[S]" --> s2
-  s2 -- "[*] → [K]/[R]" --> s3
-  s3 -- "['*'] → [K]/[S]" --> s2
-  s3 -- "[B] → [K]/[S]" --> c1
-  s4 -- "[*] → [K]/[S]" --> s6
-  s6 -- "[*] → ['*']/[S]" --> s0
+  idle -. enter .-> s4
+  s4 == "call" ==> s1
+  w_1 -. "return" .-> s4
+  s4 --> s3
+  s1 -- "[*] → [K]/[R]" --> s2
+  s2 -- "['*'] → [K]/[S]" --> s1
+  s2 -- "[B] → [K]/[S]" --> c1
+  s3 -- "[*] → [K]/[S]" --> s5
+  s5 -- "[*] → ['*']/[S]" --> s0
+  classDef tag_main fill:#dbeafe,stroke:#1e40af
+  classDef tag_rightToBlank fill:#dbeafe,stroke:#1e40af
+  class s4 tag_main
+  class s1 tag_rightToBlank
 ```
 
 The `call('rightToBlank')` step at instruction 1 is built using the engine's `withOverriddenHaltState` composition primitive: the subroutine's halt is overridden to point at the next top-level instruction (instead of terminating the machine), so when the subroutine "halts" it actually returns to top-level execution at instruction 2.
 
-Reading the diagram (engine v7's callable-subtree emit):
-- The labels are PostMachine's instruction-derived names: `"rightToBlank::1"`/`"rightToBlank::2"` for the subroutine body, `"2"` for the top-level mark, `"1~2"` for the continuation, the bare hopper name `"rightToBlank"` on the in-subgraph entry to the subtree, and the composite `"rightToBlank(1~2)"` on the wrapper itself (the `[[…]]` double-square node `s5`). The `s\d+` node IDs are still auto-generated and shift between runs.
-- The wrapper `s5[["rightToBlank(1~2)"]]` is the **call site** — it sits OUTSIDE the subgraph. The `idle -. enter .-> s5` edge marks it as the top-level entry. The double-square `[[…]]` shape signals "wrapper" — a state produced by `withOverriddenHaltState`. The wrapper has no transitions of its own; it delegates to the bare via the bold `== "call" ==>` arrow.
-- The `subgraph w_1["callable subtree of rightToBlank"]` is the **callable body** — it contains the hopper `s1`, the body states `s2`/`s3`, and a frame-local halt marker `c1`. The body's halt-bound transition (`s3 -- "[B]" --> c1`) lands on `c1`, not on the real `s0` halt.
-- The dotted `w_1 -. "return" .-> s5` is the **return arrow** — when the body lands on `c1`, control returns to the wrapper `s5`. Then `s5 --> s4` (the solid wrapper-to-override arrow) hands off to the continuation. This replaces the alpha.1 `-. onHalt .->` keyword.
-- `s4` is the continuation; it falls through (keep+S) to `s6`.
-- `s6` is the `mark` instruction at top-level 2 (writes `'*'`, then transitions to halt — the trailing top-level `3: stop` is what produces that halt edge).
+Reading the diagram (engine v7's callable-subtree emit + PostMachine's drop-acyclic-hopper rule from [#85](https://github.com/mellonis/post-machine-js/issues/85)):
+- The labels are PostMachine's instruction-derived names: `"rightToBlank::1"`/`"rightToBlank::2"` for the subroutine body, `"2"` for the top-level mark, `"1~2"` for the continuation, and the composite `"rightToBlank::1(1~2)"` on the wrapper (the `[[…]]` double-square node `s4`). The `<br>main` and `<br>rightToBlank` suffixes are auto-tag annotations (#86) — the entry points of the top-level program and the subroutine, respectively. The `s\d+` node IDs are still auto-generated and shift between runs.
+- The wrapper `s4[["rightToBlank::1(1~2)<br>main"]]` is the **call site** — it sits OUTSIDE the subgraph. The `idle -. enter .-> s4` edge marks it as the top-level entry; the auto-tag `main` reflects that role. The double-square `[[…]]` shape signals "wrapper" — a state produced by `withOverriddenHaltState`. The wrapper has no transitions of its own; it delegates to the bare via the bold `== "call" ==>` arrow. Under [#85](https://github.com/mellonis/post-machine-js/issues/85), the wrapper now wraps `rightToBlank::1` (the first instruction) directly — there is no v6.x "hopper" anchor for this acyclic-in-the-call-graph case.
+- The `subgraph w_1["callable subtree of rightToBlank::1"]` is the **callable body** — it contains the bare entry `s1` (auto-tagged `rightToBlank` as the subroutine entry), the second-instruction state `s2`, and a frame-local halt marker `c1`. The body's halt-bound transition (`s2 -- "[B]" --> c1`) lands on `c1`, not on the real `s0` halt.
+- The dotted `w_1 -. "return" .-> s4` is the **return arrow** — when the body lands on `c1`, control returns to the wrapper `s4`. Then `s4 --> s3` (the solid wrapper-to-override arrow) hands off to the continuation. This replaces the alpha.1 `-. onHalt .->` keyword.
+- `s3` is the continuation; it falls through (keep+S) to `s5`.
+- `s5` is the `mark` instruction at top-level 2 (writes `'*'`, then transitions to halt — the trailing top-level `3: stop` is what produces that halt edge).
+- The trailing `classDef tag_main` / `classDef tag_rightToBlank` + `class` lines are auto-tag styling (see [Auto-tag policy](#auto-tag-policy)).
 
 That's just syntax — for one call site, inlining is equivalent. Subroutines earn their keep when the same logic appears at multiple sites or when symmetric variants share a shape. Example: extend a marked region by one cell on each side, using mirrored `walkRightToBlank` / `walkLeftToBlank` helpers.
 
@@ -471,6 +483,92 @@ For programmatic lookup by instruction index, use `pm.candidatesFor(path)` (cons
 
 Engine v7 (upstream `@turing-machine-js/machine`) changed the wrapper composite shape from `A>B` to `A(B)` (paren-based). PostMachine's naming convention was designed to survive that change: none of our separators (`::`, `.`, `~`) collide with the new paren grammar, so only the *wrapper composite emit* shifted (e.g., the v6.x `"foo>10~40"` is now `"foo(10~40)"`). The names PostMachine constructs internally — and the rules in the table above — are unchanged. v7's `toMermaid` output also adopted a callable-subtree model: the wrapper is a `[[bare(continuation)]]` call site OUTSIDE the subgraph, with a bold `==> "call"` arrow into the bare's subtree and a dotted `-. "return" .->` arrow back to the wrapper. Replaces v6.x's composite-named entry node.
 
+## Tags
+
+Tags are out-of-band string labels attached to states. They don't change runtime behavior — they layer semantic meaning over the auto-generated path-derived names ([Naming convention](#naming-convention)) for two surfaces:
+
+- **Mermaid diagrams** — `toMermaid` emits tags as `<br>`-suffixed annotations on node labels plus `classDef`/`class` lines for visual grouping. A reader who didn't write the program sees what the structurally important entry points are without re-deriving them from the instruction list.
+- **Programmatic introspection** — `pm.findByTag(...)` retrieves paths by tag; debugger / analysis code can use tags as stable handles independent of state IDs.
+
+Three ways to apply tags: the **inline `$tag` decorator** at construction, the **`pm.tag` registry** post-construction, and the **auto-tag policy** which marks each program's / subroutine's entry point automatically.
+
+### Inline `$tag` decorator
+
+`$tag(...tags, command)` wraps a command with one or more tags. The tags apply to the resulting State; no extra graph node is created. The leading `$` flags it visually as a decorator (not a primitive command).
+
+```javascript
+import { PostMachine, $tag, check, mark, right, stop } from '@post-machine-js/machine';
+
+const machine = new PostMachine({
+  10: $tag('hot', check(20, 30)),         // tag a single state
+  20: $tag('loop-body', 'sampled', right(10)),  // variadic — many tags at once
+  30: mark,
+  40: stop,
+});
+
+console.log(machine.tagsOf({ instructionIndex: 10 }));
+// ['hot', 'main'] — inline 'hot' applied at producer time, then 'main' auto-tag
+```
+
+`$tag` rejects groups — `$tag('foo', [mark, right])` throws at construction. Tag each member individually: `[$tag('lift', mark), $tag('descend', right)]`. Passing bare `$tag` (without invoking it) as an instruction also throws with a helpful message.
+
+### Post-construction registry
+
+```typescript
+pm.tag(path: Path | string, ...tags: string[]): void;
+pm.untag(path: Path | string, ...tags: string[]): void;
+pm.tagsOf(path: Path | string): readonly string[];
+pm.findByTag(tag: string): Path[];
+```
+
+`tag` / `untag` are variadic (one call adds/removes any number of tags). `tagsOf` returns a frozen snapshot; `findByTag` returns all paths whose state currently carries that tag. All four resolve `path` the same way as [`pm.stateAt`](#path-based-resolver) — string form (`'10'`, `'sub::1'`) or object form (`{ instructionIndex: 10 }`).
+
+```javascript
+import { PostMachine, mark, stop } from '@post-machine-js/machine';
+
+const machine = new PostMachine({ 10: mark, 20: mark, 30: stop });
+machine.tag('10', 'checkpoint');
+machine.tag('20', 'checkpoint', 'hot');
+
+console.log(machine.tagsOf('20'));         // ['checkpoint', 'hot'] — no 'main' (20 is not the entry)
+console.log(machine.findByTag('checkpoint').length); // 2
+
+machine.untag('20', 'hot');
+console.log(machine.tagsOf('20'));         // ['checkpoint']
+```
+
+`pm.tag(...)` and `$tag(...)` compose: tags from both sources accumulate on the same state. Inline tags are applied at construction, before any post-construction `pm.tag` call sees the state.
+
+### Auto-tag policy
+
+At construction, PostMachine auto-tags the **entry point** of each program/subroutine:
+
+| Path | Auto-tag |
+|---|---|
+| Top-level entry (e.g., the first numbered instruction `1` or `10`) | `'main'` |
+| Each subroutine's entry (e.g., `sub::1`, `rightToBlank::1`) | the subroutine name (e.g., `'sub'`, `'rightToBlank'`) |
+
+Non-entry instructions and group inner states stay clean. Halt-resolving paths (`stop`-only entries) are also skipped, because `stop` resolves to the engine's globally-shared `haltState` singleton — tagging it would leak across all PostMachine instances. The policy is mechanical and intentionally minimal: it anchors the structural roles without cluttering diagrams.
+
+```javascript
+import { PostMachine, call, check, mark, right, stop } from '@post-machine-js/machine';
+
+const machine = new PostMachine({
+  10: call('rightToBlank'),
+  20: stop,
+  rightToBlank: { 1: check(2, 99), 2: right(1), 99: stop },
+});
+
+console.log(machine.tagsOf('10'));              // ['main']           — top-level entry
+console.log(machine.tagsOf('rightToBlank::1')); // ['rightToBlank']   — subroutine entry
+console.log(machine.tagsOf('rightToBlank::2')); // []                 — body, non-entry
+console.log(machine.findByTag('main').map((p) => p.instructionIndex)); // [10]
+```
+
+### Mermaid output
+
+When tags are present (auto-tag or user-applied), `toMermaid` emits them inline in node labels via `<br>` and as `classDef`/`class` lines for color grouping. The styling palette is hashed deterministically per tag name — same tag name → same color across runs. See the [Visualization](#visualization--tomermaid--statetograph) section below for full example output.
+
 ## Introspection and equivalence
 
 The v3 utilities from [`@turing-machine-js/machine`](https://github.com/mellonis/turing-machine-js/tree/master/packages/machine) work directly against a `PostMachine`. For the two most common ones — `summarize` and `equivalentOn` — this package also ships Post-aware free-function wrappers (`summarizePostMachine`, `equivalentPostMachines`) that bind the standard arguments and hide the `getTapeBlock`-must-clone footgun. **Prefer the wrappers for typical use.** The bare upstream functions are still re-exported here for advanced cases.
@@ -497,7 +595,7 @@ The full rendered emit for this machine:
 flowchart TD
 %% alphabets: [[" ","*"]]
   s0(((halt)))
-  s1["10"]
+  s1["10<br>main"]
   s2["20"]
   s3["30"]
   idle([idle])
@@ -506,6 +604,8 @@ flowchart TD
   s1 -- "[B] → [K]/[S]" --> s3
   s2 -- "[*] → [K]/[R]" --> s1
   s3 -- "[*] → ['*']/[S]" --> s0
+  classDef tag_main fill:#dbeafe,stroke:#1e40af
+  class s1 tag_main
 ```
 
 (Same machine as the [Quick start](#quick-start) example — see that section for the node/edge-shape reading guide.)
@@ -562,7 +662,7 @@ The two state graphs as the engine emits them — what the numbers above are sum
 flowchart TD
 %% alphabets: [[" ","*"]]
   s0(((halt)))
-  s1["10"]
+  s1["10<br>main"]
   s2["20"]
   s3["30"]
   idle([idle])
@@ -571,6 +671,8 @@ flowchart TD
   s1 -- "[B] → [K]/[S]" --> s3
   s2 -- "[*] → [K]/[R]" --> s1
   s3 -- "[*] → ['*']/[S]" --> s0
+  classDef tag_main fill:#dbeafe,stroke:#1e40af
+  class s1 tag_main
 ```
 
 `s1` is `check`; on `'*'` it loops via `s2` (`right`); on blank it falls to `s3` (`mark`) → halt. Four nodes, one back-edge, zero subgraphs.
@@ -586,10 +688,10 @@ flowchart TD
   s0(((halt)))
   s6["10~20"]
   s8["20"]
-  s7[["walkToBlank::1(10~20)"]]
+  s7[["walkToBlank::1(10~20)<br>main"]]
   idle([idle])
   subgraph w_4["callable subtree of walkToBlank::1"]
-    s4["walkToBlank::1"]
+    s4["walkToBlank::1<br>walkToBlank"]
     s5["walkToBlank::2"]
     c4(((halt)))
   end
@@ -602,6 +704,10 @@ flowchart TD
   s5 -- "[*] → [K]/[R]" --> s4
   s6 -- "[*] → [K]/[S]" --> s8
   s8 -- "[*] → ['*']/[S]" --> s0
+  classDef tag_main fill:#dbeafe,stroke:#1e40af
+  classDef tag_walkToBlank fill:#ede9fe,stroke:#5b21b6
+  class s7 tag_main
+  class s4 tag_walkToBlank
 ```
 
 The two extra nodes vs inline that drive `stateCount: 4 → 6`:

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@post-machine-js/machine",
-  "version": "7.0.0-alpha.3",
+  "version": "7.0.0-alpha.4",
   "description": "A convenient Post machine",
   "engines": {
     "npm": ">=7.0.0"
@@ -28,10 +28,10 @@
     "machine"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^7.0.0-alpha.2"
+    "@turing-machine-js/machine": "^7.0.0-alpha.3"
   },
   "devDependencies": {
-    "@turing-machine-js/machine": "^7.0.0-alpha.2"
+    "@turing-machine-js/machine": "^7.0.0-alpha.3"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/machine/src/classes/PostMachine.examples.spec.ts
+++ b/packages/machine/src/classes/PostMachine.examples.spec.ts
@@ -5,7 +5,7 @@ import {
   alphabet,
   blankSymbol,
   markSymbol,
-  call, check, left, mark, noop, right, stop,
+  $tag, call, check, left, mark, noop, right, stop,
   toMermaid,
   summarizePostMachine,
   equivalentPostMachines,
@@ -74,7 +74,8 @@ describe('packages/machine/README.md', () => {
         const mermaid = toMermaid(State.toGraph(machine.initialState, machine.tapeBlock));
 
         // 3 reachable instructions (`40: stop` is elided — see trailing-stop test below).
-        expect(mermaid).toContain('["10"]');
+        // Entry-point auto-tag (#86) appends `<br>main` to the top-level entry's label.
+        expect(mermaid).toContain('["10<br>main"]');
         expect(mermaid).toContain('["20"]');
         expect(mermaid).toContain('["30"]');
         // noop's signature: `[K]/[S]` — keep, stay. Marks have `['*']/[S]`.
@@ -93,7 +94,8 @@ describe('packages/machine/README.md', () => {
         const mermaid = toMermaid(State.toGraph(machine.initialState, machine.tapeBlock));
 
         // Only instruction 10 appears; 20/30 are unreachable, 40 = trailing stop.
-        expect(mermaid).toContain('["10"]');
+        // Entry-point auto-tag (#86) appends `<br>main` to the top-level entry's label.
+        expect(mermaid).toContain('["10<br>main"]');
         expect(mermaid).not.toContain('"20"');
         expect(mermaid).not.toContain('"30"');
         // 10's transition is noop's `[K]/[S]` straight to halt (s0).
@@ -110,7 +112,8 @@ describe('packages/machine/README.md', () => {
 
         const mermaid = toMermaid(State.toGraph(machine.initialState, machine.tapeBlock));
 
-        expect(mermaid).toContain('["10"]');
+        // Entry-point auto-tag (#86) appends `<br>main` to the top-level entry's label.
+        expect(mermaid).toContain('["10<br>main"]');
         // No "20" label — the trailing stop is elided as a halt routing
         // convention; instruction 10 transitions straight to s0(((halt))).
         expect(mermaid).not.toContain('"20"');
@@ -225,10 +228,14 @@ describe('packages/machine/README.md', () => {
       // reflect the bare's identity.
       expect(mermaid).toContain('(((halt)))');
       expect(mermaid).toMatch(/subgraph w_\d+\["callable subtree of rightToBlank::1"\]/);
-      expect(mermaid).toContain('[["rightToBlank::1(1~2)"]]');
-      expect(mermaid).toContain('["rightToBlank::1"]'); // bare inside the subgraph
+      // Wrapper bears the top-level entry auto-tag `main` (#86).
+      expect(mermaid).toContain('[["rightToBlank::1(1~2)<br>main"]]');
+      // Bare inside the subgraph bears the subroutine-entry auto-tag (#86).
+      expect(mermaid).toContain('["rightToBlank::1<br>rightToBlank"]');
       // The v6.x hopper named 'rightToBlank' is dropped (acyclic + plain first instr).
-      expect(mermaid).not.toContain('["rightToBlank"]');
+      // The bare's display label is now `rightToBlank::1<br>rightToBlank`, so the
+      // bare 'rightToBlank' (without `::1`) does not appear as a node label.
+      expect(mermaid).not.toMatch(/s\d+\["rightToBlank"\]/);
 
       // Bold `== "call" ==>` from wrapper to bare + dotted `-. "return" .->`
       // from subgraph back to wrapper. The retired alpha.1 `-. onHalt .->`
@@ -376,6 +383,54 @@ describe('packages/machine/README.md', () => {
     });
   });
 
+  describe('Tags', () => {
+    describe('Inline $tag decorator', () => {
+      test('$tag wraps a command and accumulates with the auto-tag', () => {
+        const machine = new PostMachine({
+          10: $tag('hot', check(20, 30)),
+          20: $tag('loop-body', 'sampled', right(10)),
+          30: mark,
+          40: stop,
+        });
+
+        // Insertion order: inline tag applied at producer time, auto-tag last.
+        expect(machine.tagsOf({ instructionIndex: 10 })).toEqual(['hot', 'main']);
+        // Non-entry instruction — no auto-tag, just the two inline tags.
+        expect(machine.tagsOf({ instructionIndex: 20 })).toEqual(['loop-body', 'sampled']);
+      });
+    });
+
+    describe('Post-construction registry', () => {
+      test('pm.tag / pm.untag / pm.tagsOf / pm.findByTag', () => {
+        const machine = new PostMachine({ 10: mark, 20: mark, 30: stop });
+        machine.tag('10', 'checkpoint');
+        machine.tag('20', 'checkpoint', 'hot');
+
+        // 20 is not the entry, so no 'main' — just user tags.
+        expect(machine.tagsOf('20')).toEqual(['checkpoint', 'hot']);
+        expect(machine.findByTag('checkpoint')).toHaveLength(2);
+
+        machine.untag('20', 'hot');
+        expect(machine.tagsOf('20')).toEqual(['checkpoint']);
+      });
+    });
+
+    describe('Auto-tag policy', () => {
+      test('entry-only auto-tagging: top-level entry → "main", subroutine entry → sub name', () => {
+        const machine = new PostMachine({
+          10: call('rightToBlank'),
+          20: stop,
+          rightToBlank: { 1: check(2, 99), 2: right(1), 99: stop },
+        });
+
+        expect(machine.tagsOf('10')).toEqual(['main']);
+        expect(machine.tagsOf('rightToBlank::1')).toEqual(['rightToBlank']);
+        expect(machine.tagsOf('rightToBlank::2')).toEqual([]);
+        expect(machine.findByTag('main').map((p) => p.instructionIndex)).toEqual([10]);
+      });
+    });
+  });
+
   describe('Introspection and equivalence', () => {
     describe('Visualization — toMermaid + State.toGraph', () => {
       function buildQuickStart(): PostMachine {
@@ -412,10 +467,12 @@ describe('packages/machine/README.md', () => {
 
         // Initial state — square-bracket node shape; under engine v7 the entry is
         // marked by a separate idle sentinel + dotted enter edge, not a double-paren shape.
-        expect(mermaid).toContain('["10"]');
+        // Entry-point auto-tag (#86) appends `<br>main`.
+        expect(mermaid).toContain('["10<br>main"]');
         expect(mermaid).toContain('idle([idle])');
         expect(mermaid).toMatch(/idle -\. enter \.-> s\d+/);
         // Two intermediate states — square-bracket node shape with instruction-derived names.
+        // Non-entry instructions carry no auto-tag.
         expect(mermaid).toContain('["20"]');
         expect(mermaid).toContain('["30"]');
 
@@ -484,11 +541,13 @@ describe('packages/machine/README.md', () => {
 
         // withSubroutine: wrapper outside the subgraph + callable-subtree shape.
         // Under #85 the hopper is dropped — the wrapper wraps walkToBlank::1
-        // directly, not a bare named 'walkToBlank'.
+        // directly, not a bare named 'walkToBlank'. Under #86 the wrapper bears
+        // the top-level entry-point auto-tag `main`; the bare bears the
+        // subroutine-entry auto-tag `walkToBlank`.
         expect(subMermaid).toMatch(/subgraph w_\d+\["callable subtree of walkToBlank::1"\]/);
-        expect(subMermaid).toContain('[["walkToBlank::1(10~20)"]]'); // wrapper composite
-        expect(subMermaid).toContain('["walkToBlank::1"]');          // bare, inside subgraph
-        expect(subMermaid).not.toContain('["walkToBlank"]');         // hopper dropped
+        expect(subMermaid).toContain('[["walkToBlank::1(10~20)<br>main"]]'); // wrapper composite
+        expect(subMermaid).toContain('["walkToBlank::1<br>walkToBlank"]');   // bare, inside subgraph
+        expect(subMermaid).not.toMatch(/s\d+\["walkToBlank"\]/);             // hopper dropped
         expect(subMermaid).toContain('["10~20"]');                // continuation
         expect(subMermaid).toMatch(/s\d+ == "call" ==> s\d+/);    // wrapper → bare
         expect(subMermaid).toMatch(/w_\d+ -\. "return" \.-> s\d+/);

--- a/packages/machine/src/classes/PostMachine.tags.spec.ts
+++ b/packages/machine/src/classes/PostMachine.tags.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'vitest';
+import {
+  PostMachine,
+  $tag, check, mark, right, stop,
+} from '../index';
+
+// Path-based tag registry + auto-tag policy (post-machine-js #86).
+//
+// API:
+//   pm.tag(path, ...tags)       — add one or more tags to the state at path
+//   pm.untag(path, ...tags)     — remove tags (no-op if not present)
+//   pm.tagsOf(path)             — frozen snapshot of the state's tags
+//   pm.findByTag(tag)           — all paths whose state carries that tag
+//
+// All four forward to the engine's `state.tag(...) / .untag(...) / .tags`
+// API (engine #186). PostMachine does NOT maintain its own tag storage.
+//
+// Auto-tag policy (applied at construction):
+//   - The ENTRY POINT of the top-level program → tagged 'main'  (e.g. path '1')
+//   - Each subroutine's entry state             → tagged with the subroutine name (e.g. path 'alg::1' → 'alg')
+//
+// Only the entry-point state of each program/subroutine gets an auto-tag.
+// Other top-level instructions and subroutine body instructions stay clean,
+// keeping diagrams uncluttered while still anchoring the structural roles.
+
+describe('pm.tag / pm.untag / pm.tagsOf / pm.findByTag — registry API (#86)', () => {
+  test('pm.tag adds a tag to the state at path (string form)', () => {
+    const pm = new PostMachine({ 10: mark, 20: stop });
+    pm.tag('10', 'hot');
+    expect(pm.tagsOf('10')).toContain('hot');
+  });
+
+  test('pm.tag adds a tag to the state at path (object form)', () => {
+    const pm = new PostMachine({ 10: mark, 20: stop });
+    pm.tag({ instructionIndex: 10 }, 'hot');
+    expect(pm.tagsOf({ instructionIndex: 10 })).toContain('hot');
+  });
+
+  test('pm.tag is variadic — adds multiple tags in one call', () => {
+    const pm = new PostMachine({ 10: mark, 20: stop });
+    pm.tag('10', 'hot', 'sampled', 'entry');
+    expect(pm.tagsOf('10')).toEqual(expect.arrayContaining(['hot', 'sampled', 'entry']));
+  });
+
+  test('pm.untag removes a tag (subsequent tagsOf no longer contains it)', () => {
+    const pm = new PostMachine({ 10: mark, 20: stop });
+    pm.tag('10', 'hot');
+    pm.untag('10', 'hot');
+    expect(pm.tagsOf('10')).not.toContain('hot');
+  });
+
+  test('pm.untag is a no-op for tags that were never added', () => {
+    const pm = new PostMachine({ 10: mark, 20: stop });
+    expect(() => pm.untag('10', 'never-added')).not.toThrow();
+  });
+
+  test('pm.tagsOf returns a frozen array', () => {
+    const pm = new PostMachine({ 10: mark, 20: stop });
+    pm.tag('10', 'hot');
+    const tags = pm.tagsOf('10');
+    expect(Object.isFrozen(tags)).toBe(true);
+  });
+
+  test('pm.findByTag returns all paths carrying that tag', () => {
+    const pm = new PostMachine({ 10: mark, 20: mark, 30: stop });
+    pm.tag('10', 'hot');
+    pm.tag('20', 'hot');
+    const paths = pm.findByTag('hot');
+    expect(paths).toHaveLength(2);
+    expect(paths.some((p) => p.instructionIndex === 10)).toBe(true);
+    expect(paths.some((p) => p.instructionIndex === 20)).toBe(true);
+  });
+
+  test('pm.findByTag returns [] for an unknown tag', () => {
+    const pm = new PostMachine({ 10: mark, 20: stop });
+    expect(pm.findByTag('never-added')).toEqual([]);
+  });
+
+  test('pm.tag throws on an unknown path', () => {
+    const pm = new PostMachine({ 10: mark, 20: stop });
+    expect(() => pm.tag('99', 'hot')).toThrow(/does not resolve/);
+  });
+
+  test('user tags and inline $tag(...) decorator compose on the same state', () => {
+    const pm = new PostMachine({
+      10: $tag('inline', mark),
+      20: stop,
+    });
+    pm.tag('10', 'post-hoc');
+    expect(pm.tagsOf('10')).toEqual(expect.arrayContaining(['inline', 'post-hoc']));
+  });
+});
+
+describe('auto-tag policy at construction (#86)', () => {
+  test('the top-level entry point is tagged "main"', () => {
+    const pm = new PostMachine({ 10: mark, 20: mark, 30: stop });
+    expect(pm.tagsOf('10')).toContain('main');
+  });
+
+  test('non-entry top-level instructions are NOT auto-tagged', () => {
+    const pm = new PostMachine({ 10: mark, 20: mark, 30: stop });
+    expect(pm.tagsOf('20')).not.toContain('main');
+  });
+
+  test('halt-resolving entry points are NOT auto-tagged', () => {
+    // `stop` resolves to the engine's haltState singleton, which is globally
+    // shared. Tagging it would leak the tag across all PostMachine instances
+    // — so auto-tag skips halt-resolving paths even when they're entries.
+    const pm = new PostMachine({ 10: stop });
+    expect(pm.tagsOf('10')).not.toContain('main');
+  });
+
+  test('subroutine entry state is tagged with the subroutine name', () => {
+    const pm = new PostMachine({
+      10: check(20, 30),
+      20: right(10),
+      30: stop,
+      rightToBlank: { 1: mark, 2: stop },
+    });
+    expect(pm.tagsOf('rightToBlank::1')).toContain('rightToBlank');
+  });
+
+  test('subroutine body states (non-entry) are NOT auto-tagged with the sub name', () => {
+    const pm = new PostMachine({
+      10: stop,
+      sub: { 1: mark, 2: stop },
+    });
+    // Entry (instruction 1) carries the tag; subsequent body instructions do not.
+    expect(pm.tagsOf('sub::1')).toContain('sub');
+    expect(pm.tagsOf('sub::2')).not.toContain('sub');
+  });
+
+  test('subroutine entry is NOT tagged "main" (it belongs to the subroutine, not the top-level program)', () => {
+    const pm = new PostMachine({
+      10: stop,
+      sub: { 1: mark, 2: stop },
+    });
+    expect(pm.tagsOf('sub::1')).not.toContain('main');
+  });
+
+  test('findByTag("main") returns just the top-level entry-point path', () => {
+    const pm = new PostMachine({
+      10: mark,
+      20: mark,
+      30: stop,
+      sub: { 1: mark, 2: stop },
+    });
+    const paths = pm.findByTag('main');
+    expect(paths).toHaveLength(1);
+    expect(paths[0].instructionIndex).toBe(10);
+  });
+
+  test('user pm.tag composes with auto-tags — both coexist on the entry state', () => {
+    const pm = new PostMachine({ 10: mark, 20: stop });
+    pm.tag('10', 'hot');
+    expect(pm.tagsOf('10')).toEqual(expect.arrayContaining(['main', 'hot']));
+  });
+});

--- a/packages/machine/src/classes/PostMachine.ts
+++ b/packages/machine/src/classes/PostMachine.ts
@@ -19,7 +19,7 @@ import {
 } from '../consts';
 import type { CommandContext, Instructions } from '../commands';
 import {
-  call, check, erase, left, mark, noop, right, stop,
+  $tag, call, check, erase, left, mark, noop, right, stop,
 } from '../commands';
 import { instructionIndexValidator, subroutineNameValidator, validateSymbolPair } from '../validators';
 import { installStateLockdown, withLockdownEscape } from '../lockdown';
@@ -450,6 +450,12 @@ export class PostMachine extends TuringMachine {
           .every((command) => commandsSet.has(command as CommandFn));
 
         if (!areInstructionsInGroupValid) {
+          if (instruction.includes($tag as never)) {
+            throw new Error(
+              'bare `$tag` decorator in a group — `$tag` must be invoked, '
+              + 'e.g. `[$tag(\'hot\', mark), right]`',
+            );
+          }
           throw new Error('invalid command in the group');
         }
 
@@ -485,6 +491,11 @@ export class PostMachine extends TuringMachine {
             nextState,
           },
         }, continuationName)));
+      } else if (instruction === $tag) {
+        throw new Error(
+          'bare `$tag` decorator passed as an instruction — `$tag` must be '
+          + 'invoked, e.g. `10: $tag(\'hot\', mark)`',
+        );
       } else {
         throw new Error('invalid instruction');
       }
@@ -505,6 +516,23 @@ export class PostMachine extends TuringMachine {
           };
 
       this.#recordPath(state, path);
+
+      // Auto-tag policy (#86). Only the ENTRY POINT of each program /
+      // subroutine gets an auto-tag — `1` for main, `alg::1` for subroutine
+      // `alg` — to keep diagrams uncluttered while still anchoring the
+      // structural roles. Group inner states and halt-resolving paths are
+      // skipped (halt is a globally-shared singleton and can't be safely
+      // tagged).
+      if (
+        groupOuterInstructionIndex === undefined
+        && !state.isHalt
+        && Number(instructionIndexStr) === list[0]
+      ) {
+        const tagName = scope.length === 0
+          ? 'main'
+          : scope[scope.length - 1];
+        state.tag(tagName);
+      }
     });
 
     return references[instructionIndexList[0]].ref;
@@ -561,6 +589,31 @@ export class PostMachine extends TuringMachine {
   candidatesFor(target: Path | string): Path[] {
     const { state } = this.#resolveToState(target);
     return this.#stateToCandidatePaths.get(state)!;
+  }
+
+  tag(target: Path | string, ...tags: string[]): void {
+    const { state } = this.#resolveToState(target);
+    state.tag(...tags);
+  }
+
+  untag(target: Path | string, ...tags: string[]): void {
+    const { state } = this.#resolveToState(target);
+    state.untag(...tags);
+  }
+
+  tagsOf(target: Path | string): readonly string[] {
+    const { state } = this.#resolveToState(target);
+    return state.tags;
+  }
+
+  findByTag(tag: string): Path[] {
+    const results: Path[] = [];
+    for (const [state, paths] of this.#stateToCandidatePaths) {
+      if (state.tags.includes(tag)) {
+        results.push(...paths);
+      }
+    }
+    return results;
   }
 
   setBreakpoint(target: BreakpointTarget, filter: BreakpointFilter): void {

--- a/packages/machine/src/commands.spec.ts
+++ b/packages/machine/src/commands.spec.ts
@@ -56,6 +56,33 @@ describe('$tag — inline tag decorator (#86)', () => {
     })).toThrow(/group/i);
   });
 
+  test('per-member `$tag` inside a group works — tags apply to each inner state', () => {
+    // The recommended workaround for "tag inside a group" — wrap each
+    // member individually instead of wrapping the group as a whole.
+    const machine = new PostMachine({
+      10: [$tag('lift', mark), $tag('descend', right)],
+      20: stop,
+    });
+
+    // Inner group instructions carry their per-member tags.
+    expect(machine.tagsOf({ instructionIndex: 10, groupInstructionIndex: 1 }))
+      .toEqual(['lift']);
+    expect(machine.tagsOf({ instructionIndex: 10, groupInstructionIndex: 2 }))
+      .toEqual(['descend']);
+
+    // The outer group wrapper at path '10' is the top-level entry — it
+    // carries only the auto-tag 'main', not the inner-member tags.
+    expect(machine.tagsOf('10')).toEqual(['main']);
+
+    // findByTag returns the group-inner path for each member tag.
+    expect(machine.findByTag('lift')).toEqual([
+      { instructionIndex: 10, groupInstructionIndex: 1 },
+    ]);
+    expect(machine.findByTag('descend')).toEqual([
+      { instructionIndex: 10, groupInstructionIndex: 2 },
+    ]);
+  });
+
   test('rejects calls with no tags', () => {
     expect(() => new PostMachine({
       10: ($tag as unknown as (...args: unknown[]) => unknown)(mark) as never,

--- a/packages/machine/src/commands.spec.ts
+++ b/packages/machine/src/commands.spec.ts
@@ -1,0 +1,124 @@
+import {describe, expect, test} from 'vitest';
+
+import {PostMachine, $tag, mark, noop, right, stop} from './index';
+import {State, toMermaid} from '@turing-machine-js/machine';
+
+// Tests for the `$tag('label', command)` inline decorator (#86).
+//
+// The `$tag` decorator wraps a command producer (or bare constructor) with
+// one or more tags. Tags get applied to the resulting State via the engine's
+// `state.tag(...)` API (engine #186). Composes with indexed commands
+// (`$tag('hot', check(20, 30))`), rejects groups (`$tag('foo', [mark, right])`
+// throws — tag the inner commands individually instead). The `$` prefix
+// flags it as a decorator (not a primitive command) at the call site.
+
+describe('$tag — inline tag decorator (#86)', () => {
+  test('tags a bare command (constructor form)', () => {
+    const machine = new PostMachine({
+      10: $tag('hot', mark),
+      20: stop,
+    });
+
+    const state = machine.stateAt({instructionIndex: 10});
+
+    expect(state).toBeDefined();
+    expect(state!.tags).toContain('hot');
+  });
+
+  test('tags a command-with-explicit-jump (producer form)', () => {
+    const machine = new PostMachine({
+      10: $tag('hot', mark(30)),
+      20: noop,
+      30: stop,
+    });
+
+    const state = machine.stateAt({instructionIndex: 10});
+
+    expect(state).toBeDefined();
+    expect(state!.tags).toContain('hot');
+  });
+
+  test('variadic — multiple tags before the command', () => {
+    const machine = new PostMachine({
+      10: $tag('hot', 'sampled', 'entry', mark),
+      20: stop,
+    });
+
+    const state = machine.stateAt({instructionIndex: 10});
+
+    expect(state!.tags).toEqual(expect.arrayContaining(['hot', 'sampled', 'entry']));
+  });
+
+  test('rejects groups — `$tag(\'label\', [mark, right])` throws at construction', () => {
+    expect(() => new PostMachine({
+      10: $tag('hot', [mark, right] as never),
+      20: stop,
+    })).toThrow(/group/i);
+  });
+
+  test('rejects calls with no tags', () => {
+    expect(() => new PostMachine({
+      10: ($tag as unknown as (...args: unknown[]) => unknown)(mark) as never,
+      20: stop,
+    })).toThrow(/at least one tag/i);
+  });
+
+  test('rejects non-string tags', () => {
+    expect(() => new PostMachine({
+      10: ($tag as unknown as (...args: unknown[]) => unknown)(42, mark) as never,
+      20: stop,
+    })).toThrow(/string/i);
+  });
+
+  test('rejects non-function final argument', () => {
+    // Final arg must be a command (function) or a group (array — handled by
+    // the group-rejection branch above). Anything else falls through to
+    // the "must be a command" throw.
+    expect(() => new PostMachine({
+      10: ($tag as unknown as (...args: unknown[]) => unknown)('hot', 42) as never,
+      20: stop,
+    })).toThrow(/must be a command/);
+  });
+
+  test('rejects bare `$tag` at top level — must be invoked', () => {
+    expect(() => new PostMachine({
+      10: $tag as never,
+      20: stop,
+    })).toThrow(/\$tag/);
+  });
+
+  test('rejects bare `$tag` inside a group — must be invoked', () => {
+    expect(() => new PostMachine({
+      10: [$tag as never],
+      20: stop,
+    })).toThrow(/\$tag/);
+  });
+
+  test('tags appear in toMermaid output (engine #186 emit)', () => {
+    const machine = new PostMachine({
+      10: $tag('hot', mark),
+      20: stop,
+    });
+
+    const mermaid = toMermaid(State.toGraph(machine.initialState, machine.tapeBlock));
+
+    // Engine #186 emits tags inline in node labels via `<br>` and as
+    // classDef/class lines for color grouping. Both should appear.
+    expect(mermaid).toContain('<br>');
+    expect(mermaid).toContain('hot');
+    expect(mermaid).toMatch(/classDef tag_hot /);
+    expect(mermaid).toMatch(/class s\d+ tag_hot/);
+  });
+
+  test('round-trip: machine reaches the tagged state and runs to completion', async () => {
+    const machine = new PostMachine({
+      10: $tag('hot', mark),
+      20: stop,
+    });
+
+    // The tag doesn't affect runtime — the machine still halts normally.
+    await machine.run();
+
+    expect(machine.tape.symbols[0]).toBe('*');
+  });
+});

--- a/packages/machine/src/commands.ts
+++ b/packages/machine/src/commands.ts
@@ -354,3 +354,83 @@ commandsSet.add(mark as CommandFn);
 commandsSet.add(noop as CommandFn);
 commandsSet.add(right as CommandFn);
 commandsSet.add(stop as CommandFn);
+
+/**
+ * Inline `$tag` decorator (#86). Wraps a command (bare constructor like
+ * `mark` or already-bound producer like `mark(20)` / `call('foo')`) with
+ * one or more tags; tags are applied to the resulting State via the
+ * engine's `state.tag(...)` API (engine #186). The wrapped command's
+ * runtime behavior is unchanged — `$tag` is a decorator, not a primitive.
+ * The `$` prefix flags it as a decorator at the call site.
+ *
+ * Usage:
+ *   - Wrap a bare command:    `$tag('hot', mark)`
+ *   - Wrap an indexed command:`$tag('loop-head', check(20, 40))`
+ *   - Variadic tags:          `$tag('hot', 'sampled', 'entry', mark)`
+ *   - Compose with call:      `$tag('subroutine-entry', call('foo'))`
+ *
+ * Does NOT compose with groups — `$tag('foo', [mark, right])` throws at
+ * construction. Tag each member individually instead:
+ *   `10: [$tag('lift', mark), $tag('descend', right)]`.
+ */
+export function $tag(...args: unknown[]): CommandStateProducer {
+  if (args.length < 2) {
+    throw new Error('$tag() requires at least one tag and a command');
+  }
+
+  const tags = args.slice(0, -1);
+  const wrapped = args[args.length - 1];
+
+  for (const t of tags) {
+    if (typeof t !== 'string') {
+      throw new Error(`$tag() tags must be strings, got ${typeof t}: ${String(t)}`);
+    }
+  }
+
+  if (Array.isArray(wrapped)) {
+    throw new Error(
+      '$tag() cannot wrap a group — groups and tags are incompatible. '
+      + 'Tag each group member individually instead: `[$tag("lift", mark), $tag("descend", right)]`.',
+    );
+  }
+
+  if (typeof wrapped !== 'function') {
+    throw new Error(
+      `$tag() final argument must be a command, got ${typeof wrapped}`,
+    );
+  }
+
+  const stringTags = tags as string[];
+  const wrappedFn = wrapped as CommandStateProducer | CommandConstructor;
+
+  // Dispatch: if `wrappedFn` is a bare command constructor (mark/right/etc.),
+  // call it with `defaultNextInstructionIndex` to get the bound producer —
+  // same conversion PostMachine does at instruction-build time (see the
+  // `case erase: case left: …` switch in PostMachine.#buildInitialState).
+  // Producers already in `commandsSet` (mark(20), call('foo'), check(20, 30),
+  // $tag(...)) are invoked directly with context. `call`/`check` are excluded
+  // — bare references throw at PostMachine's dispatch, so they can't reach
+  // here without first being bound by the caller.
+  const isBareConstructor = wrappedFn === erase
+    || wrappedFn === left
+    || wrappedFn === mark
+    || wrappedFn === noop
+    || wrappedFn === right
+    || wrappedFn === stop;
+
+  const taggedProducer: CommandStateProducer = (context) => {
+    const producer: CommandStateProducer = isBareConstructor
+      ? (wrappedFn as CommandConstructor)(defaultNextInstructionIndex)
+      : wrappedFn as CommandStateProducer;
+
+    const state = producer(context);
+
+    state.tag(...stringTags);
+
+    return state;
+  };
+
+  commandsSet.add(taggedProducer as CommandFn);
+
+  return taggedProducer;
+}

--- a/packages/machine/src/index.ts
+++ b/packages/machine/src/index.ts
@@ -29,7 +29,7 @@ export type {
 } from '@turing-machine-js/machine';
 export { alphabet, blankSymbol, markSymbol } from './consts';
 export {
-  call, check, erase, left, mark, noop, right, stop,
+  $tag, call, check, erase, left, mark, noop, right, stop,
 } from './commands';
 export type {
   Instructions,


### PR DESCRIPTION
## Summary

Implements [#86](https://github.com/mellonis/post-machine-js/issues/86) — user-supplied tags on states, on top of engine alpha.3's `state.tag(...)` surface (engine #186).

- **`$tag(...tags, command)`** — inline decorator that wraps a command with one or more tags. Variadic; rejects groups; rejects bare-`$tag` misuse with a helpful message. The `$` prefix flags it visually as a decorator (not a primitive command).
- **`pm.tag / .untag / .tagsOf / .findByTag`** — path-based registry. Forwards to engine `state.tag(...) / .untag(...) / .tags`. PostMachine doesn't maintain its own tag storage.
- **Auto-tag policy** — at construction, each program/subroutine entry state is auto-tagged: top-level entry → `'main'`, subroutine entry → sub name. Halt-resolving entries are skipped to avoid tag leakage via the shared `haltState` singleton.
- **README** — new `## Tags` section documenting the three surfaces + Mermaid output shape. Existing diagram blocks updated to show `<br>main` / `<br>rightToBlank` / `<br>walkToBlank` annotations and trailing `classDef`/`class` lines. The simple-subroutine block was additionally rewritten to reflect the alpha.3 hopper-drop shape (was stale).
- **Version bump** to `7.0.0-alpha.4`. Engine peer dep unchanged (`^7.0.0-alpha.3` — alpha.3 already ships `state.tag(...)`).

Targets `v7`, not master — per the v7 integration-branch convention. The `closes #86` line is intentionally omitted here; it'll be added in the eventual `v7 → master` release PR.

## Test plan

- [x] `npm test` — 314 tests pass (+22 new: 10 `$tag` + 18 registry/auto-tag + 3 README examples + correlated updates to 6 existing README example assertions)
- [x] `npm run test:coverage` — 100/100/100/100 (statements/branches/functions/lines) floor preserved
- [x] `npm run lint`, `npm run typecheck`, `npm run build` — clean
- [ ] Smoke a tag-bearing `toMermaid` blob through `fromMermaid` to confirm engine round-trip survives (engine alpha.3 should handle this; PostMachine adds no extra surface to round-trip)
- [ ] CI green on the PR