### PR TITLE
chore: widen engine peer dep to ^7.0.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.3"
+        "@turing-machine-js/machine": "^7.0.0-alpha.4"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.13",
@@ -2740,9 +2740,9 @@
       }
     },
     "node_modules/@turing-machine-js/machine": {
-      "version": "7.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.3.tgz",
-      "integrity": "sha512-+5FW2WRikdcXM2o7qKVnWeMCFuOMIAySV01ATZoFiYlz9o797+MFxVjpSmJ3KQNqTijeXutIPlVdQl2a0VHhXA==",
+      "version": "7.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.4.tgz",
+      "integrity": "sha512-zgSXyI81koOMv4RAJhZOnCHZx5od1/j6i6dKM1+++1lsiZIEe6Ou3fxckKp6o9QjihJXfIE8QzzXX1LiOERURQ==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"
@@ -10444,13 +10444,13 @@
       "version": "7.0.0-alpha.4",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.3"
+        "@turing-machine-js/machine": "^7.0.0-alpha.4"
       },
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.3"
+        "@turing-machine-js/machine": "^7.0.0-alpha.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@turing-machine-js/machine": "^7.0.0-alpha.3"
+    "@turing-machine-js/machine": "^7.0.0-alpha.4"
   }
 }

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [7.0.0-alpha.4] - 2026-05-21
+## [7.0.0-alpha.4] - 2026-05-23
 
-Fourth v7 pre-release. Adds user-supplied tags on states ([#86](https://github.com/mellonis/post-machine-js/issues/86)) — both an inline decorator at construction and a path-based registry post-construction — plus an auto-tag policy that marks each program's/subroutine's entry state. Engine peer-dep widened `^7.0.0-alpha.3` (the new `state.tag(...)` API was added by engine alpha.3). Published to npm under the `next` dist-tag: `npm install @post-machine-js/machine@next`.
+Fourth v7 pre-release. Adds user-supplied tags on states ([#86](https://github.com/mellonis/post-machine-js/issues/86)) — both an inline decorator at construction and a path-based registry post-construction — plus an auto-tag policy that marks each program's/subroutine's entry state. Engine peer-dep widened `^7.0.0-alpha.2` → `^7.0.0-alpha.4` — alpha.3 added the `state.tag(...)` API this release builds on, and alpha.4 ships two upstream bug fixes that post inherits transparently (`toMermaid` HTML-entity-escapes user content in labels — fixes alphabet-with-`"` parse errors, [engine #194](https://github.com/mellonis/turing-machine-js/issues/194); `runStepByStep` halt stack scoped to the call, fixes a memory leak / ghost-iteration when the same machine is reused across calls, [engine #196](https://github.com/mellonis/turing-machine-js/issues/196)). Published to npm under the `next` dist-tag: `npm install @post-machine-js/machine@next`.
 
 **Pre-release — the API surface may still shift before stable v7.0.0.** Pin to a specific alpha for reproducibility: `@post-machine-js/machine@7.0.0-alpha.4`.
 

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -28,10 +28,10 @@
     "machine"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^7.0.0-alpha.3"
+    "@turing-machine-js/machine": "^7.0.0-alpha.4"
   },
   "devDependencies": {
-    "@turing-machine-js/machine": "^7.0.0-alpha.3"
+    "@turing-machine-js/machine": "^7.0.0-alpha.4"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Engine [`@turing-machine-js/machine@7.0.0-alpha.4`](https://github.com/mellonis/turing-machine-js/releases/tag/v7.0.0-alpha.4) shipped today. Widening post-machine-js's peer-dep range to accept it before this repo cuts its own alpha.4.

## What engine alpha.4 brings post

Two upstream bug fixes that post inherits transparently — no code change here, just the version bump:

- **[engine #194](https://github.com/mellonis/turing-machine-js/issues/194)** — `toMermaid` HTML-entity-escapes user content in labels (alphabet symbols, state names, tag names). Fixes the edge-label parse error when an alphabet contains literal `"`, `<`, `>`, etc. Post-side `toMermaid(machine.initialState, machine.tapeBlock)` benefits without code changes.
- **[engine #196](https://github.com/mellonis/turing-machine-js/issues/196)** — `runStepByStep` halt stack scoped to the call rather than the `TuringMachine` instance. Fixes a memory leak / ghost-iteration when the same machine is reused across consecutive `runStepByStep` calls. Post-side `runStepByStep` inherits the fix.

Two additive changes that don't affect post-machine-js's current surface:

- **[engine #195](https://github.com/mellonis/turing-machine-js/issues/195)** — `State.collectStates(initial, tapeBlock)` for id-keyed `Map<number, {state, transitionSymbols}>` lookup. Post doesn't currently surface it; could be a future post-side helper if needed (separate issue).
- **[engine #180](https://github.com/mellonis/turing-machine-js/issues/180)** — `State.toGraph` / `State.fromGraph` extracted to `utilities/stateGraph.ts`. Public surface preserved via static delegates — post is unaffected.

## Diff

```
 package-lock.json             | 12 ++++++------
 package.json                  |  2 +-
 packages/machine/CHANGELOG.md |  4 ++--
 packages/machine/package.json |  4 ++--
 4 files changed, 11 insertions(+), 11 deletions(-)
```

- `packages/machine/package.json` — peer dep AND devDep `^7.0.0-alpha.3` → `^7.0.0-alpha.4`.
- `package.json` (workspace root) — devDep widened to match, so the locally-installed engine equals what the published peer-dep range requires.
- `package-lock.json` — refreshed via `npm install`.
- `packages/machine/CHANGELOG.md` — alpha.4 entry edited:
  - Date `2026-05-21` → `2026-05-23` (publish moves to today).
  - Engine peer-dep paragraph spells out the from→to range and lists engine alpha.4's transparent fixes (#194 / #196).

## Test plan
- [x] `npm install` — clean (engine 7.0.0-alpha.4 resolved locally).
- [x] `npm test` — 315/315 pass against engine alpha.4.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean (pre-existing Rollup `this`-keyword warnings unchanged).