### PR TITLE
docs: trim historical bloat + drop stale references in source comments

### DIFF
--- a/packages/machine/src/breakpoints.spec.ts
+++ b/packages/machine/src/breakpoints.spec.ts
@@ -149,9 +149,9 @@ describe('pm.clearBreakpoint / clearBreakpoints', () => {
     pm.setBreakpoint('10', { before: true });
     pm.clearBreakpoint('10');
     expect(pm.listBreakpoints()).toEqual([]);
-    // Engine v6.1+ (#150) returns an empty `DebugConfig` after a filters
-    // reset rather than `null`. Check the public getters directly — `undefined`
-    // is the "no filter set" sentinel (field type: `symbol[] | true | undefined`).
+    // state.debug after a clear is an empty DebugConfig — read filter getters
+    // directly; `undefined` is the "no filter set" sentinel
+    // (field type: `symbol[] | true | undefined`).
     const dbg = pm.stateAt('10').debug;
     expect(dbg.before).toBeUndefined();
     expect(dbg.after).toBeUndefined();
@@ -184,7 +184,7 @@ describe('pm.clearBreakpoint / clearBreakpoints', () => {
     pm.setBreakpoint(haltState, { before: true });
     pm.clearBreakpoints();
     expect(pm.listBreakpoints()).toEqual([]);
-    // Engine v6.1+ (#150) — see clearBreakpoint test above.
+    // Empty DebugConfig after clear — see clearBreakpoint test above.
     const dbg = pm.stateAt('10').debug;
     expect(dbg.before).toBeUndefined();
     expect(dbg.after).toBeUndefined();
@@ -209,19 +209,12 @@ describe('onPause — registry-aware filtering', () => {
   });
 
   test('arrivalPath in after-fire onPause is the iter that just fired, not the next one', async () => {
-    // Regression test for the v6.1.0-v6.3.0 `advanceTracking` ordering bug.
-    // Before v6.4.0, PostMachine advanced `prev` inside its `onStep` wrapper,
-    // which runs BETWEEN engine v6's `onPause(before, K)` and `onPause(after, K)`
-    // dispatches on the same yield. So `onPause(after, K)` saw `prev = K`
-    // (advanced by onStep on the same iter) instead of `K-1` — and the path
-    // resolver "from K, with K's symbol, to ..." returned K+1's instruction,
-    // not K's. In this program, instruction 30's after-fire would have
-    // resolved to 40 (the next-fall-through instruction) instead of 30.
-    //
-    // Fixed in v6.4.0 by moving advanceTracking from the internal onStep
-    // wrapper to a new internal onIter wrapper, which fires at end-of-iter
-    // — after both onPause dispatches have already read their iter-correct
-    // prev. Engine onIter hook landed in turing-machine-js v6.4.0 (#163).
+    // Regression: after-fire onPause must see arrivalPath of the iter that
+    // fired, not the next one. Without end-of-iter prev advance,
+    // onPause(after, K) reads prev = K (advanced by onStep mid-iter) instead
+    // of K-1 — the path resolver then returns K+1's instruction.
+    // In this program, instruction 30's after-fire would resolve to 40
+    // (next fall-through) instead of 30.
     const pm = new PostMachine({
       10: check(20, 30),
       20: right(10),

--- a/packages/machine/src/callGraph.ts
+++ b/packages/machine/src/callGraph.ts
@@ -94,8 +94,6 @@ export function analyzeLocalCallGraph(
   return {cyclicSet, buildOrder};
 }
 
-// Same as `extractCallTargets` above but with the right return type. The
-// earlier function had a placeholder return; this is the real one.
 function extractCallTargetsFromInstructions(instructions: Instructions): Set<string> {
   const targets = new Set<string>();
 

--- a/packages/machine/src/classes/PostMachine.debugger.spec.ts
+++ b/packages/machine/src/classes/PostMachine.debugger.spec.ts
@@ -1,6 +1,6 @@
-// PostMachine debugger surface — async run() semantics and the experimental
-// onPause forwarding. Mirrors v3.spec.ts structure; both files
-// stay non-README (README-driven tests live in examples.spec.ts).
+// PostMachine debugger surface — async run() semantics and onPause forwarding.
+// Mirrors v3.spec.ts structure; both files stay non-README (README-driven
+// tests live in examples.spec.ts).
 
 import {
   PostMachine,
@@ -82,9 +82,8 @@ describe('PostMachine — onPause forwarding', () => {
       symbols: ['*', '*', ' '],
     }));
 
-    // Attach a `before` breakpoint on the initial state. Per turing v4,
-    // setting `state.debug` is runtime-mutable; the upstream run() loop
-    // checks it on each iteration boundary.
+    // Attach a `before` breakpoint on the initial state. `state.debug` is
+    // runtime-mutable; the upstream run() loop checks it on each iter.
     machine.initialState.debug = { before: true };
 
     const seen: MachineState[] = [];

--- a/packages/machine/src/classes/PostMachine.examples.spec.ts
+++ b/packages/machine/src/classes/PostMachine.examples.spec.ts
@@ -221,25 +221,19 @@ describe('packages/machine/README.md', () => {
       expect(mermaid).toContain('flowchart TD');
       expect(mermaid).toContain('%% alphabets: [[" ","*"]]');
 
-      // Halt + the entry — under engine v7's callable-subtree emit (#174)
-      // PLUS PostMachine's drop-acyclic-hopper change (#85), the wrapper at
-      // the call site wraps `rightToBlank::1` directly (not the v6.x hopper
-      // named `rightToBlank`). The subgraph label and composite name both
-      // reflect the bare's identity.
+      // Acyclic + plain-first-instruction → wrapper wraps `rightToBlank::1`
+      // directly; subgraph label and composite name reflect the bare's identity.
       expect(mermaid).toContain('(((halt)))');
       expect(mermaid).toMatch(/subgraph w_\d+\["callable subtree of rightToBlank::1"\]/);
-      // Wrapper bears the top-level entry auto-tag `main` (#86).
+      // Top-level entry auto-tag `main` (#86).
       expect(mermaid).toContain('[["rightToBlank::1(1~2)<br>main"]]');
-      // Bare inside the subgraph bears the subroutine-entry auto-tag (#86).
+      // Subroutine-entry auto-tag (#86).
       expect(mermaid).toContain('["rightToBlank::1<br>rightToBlank"]');
-      // The v6.x hopper named 'rightToBlank' is dropped (acyclic + plain first instr).
-      // The bare's display label is now `rightToBlank::1<br>rightToBlank`, so the
-      // bare 'rightToBlank' (without `::1`) does not appear as a node label.
+      // No bare `rightToBlank` (without `::1`) node label.
       expect(mermaid).not.toMatch(/s\d+\["rightToBlank"\]/);
 
-      // Bold `== "call" ==>` from wrapper to bare + dotted `-. "return" .->`
-      // from subgraph back to wrapper. The retired alpha.1 `-. onHalt .->`
-      // keyword does not appear; wrapper-to-override is a regular solid arrow.
+      // Bold `== "call" ==>` wrapper→bare + dotted `-. "return" .->`
+      // subgraph→wrapper. Wrapper-to-override is a regular solid arrow.
       expect(mermaid).toMatch(/s\d+ == "call" ==> s\d+/);
       expect(mermaid).toMatch(/w_\d+ -\. "return" \.-> s\d+/);
       expect(mermaid).not.toMatch(/onHalt/);
@@ -352,7 +346,7 @@ describe('packages/machine/README.md', () => {
     });
   });
 
-  describe('MachineState shape (v6.1.0+)', () => {
+  describe('MachineState shape', () => {
     test('onStep receives arrivalPath and candidatePaths for a simple machine', async () => {
       const m = new PostMachine({
         10: mark,
@@ -514,11 +508,9 @@ describe('packages/machine/README.md', () => {
         expect(a.compositionEdgeCount).toBe(0);
         expect(a.maxCompositionDepth).toBe(0);
 
-        // Under #85, `walkToBlank` is acyclic + has a plain first instruction
-        // (check), so its hopper is dropped. The subroutine contributes 2
-        // body states (walkToBlank::1, walkToBlank::2) + 1 continuation +
-        // the wrapper at instruction 10 + the top-level mark = 6 nodes
-        // (vs alpha.2's 7 with the hopper).
+        // `walkToBlank` is acyclic + plain first instruction (check), so no
+        // hopper. 6 nodes: 2 body (walkToBlank::1, walkToBlank::2) + 1
+        // continuation + wrapper at instruction 10 + top-level mark.
         // console.log(b.stateCount, b.compositionEdgeCount, b.maxCompositionDepth); // 6 1 1
         expect(b.stateCount).toBe(6);
         expect(b.compositionEdgeCount).toBe(1);
@@ -572,7 +564,7 @@ describe('packages/machine/README.md', () => {
     });
   });
 
-  describe('Path-based resolver (v6.1.0+)', () => {
+  describe('Path-based resolver', () => {
     test('top-level instruction is reachable by string and object path', () => {
       const pm = new PostMachine({ 10: mark, 20: stop });
 
@@ -595,7 +587,7 @@ describe('packages/machine/README.md', () => {
     });
   });
 
-  describe('Breakpoints (v6.1.0+)', () => {
+  describe('Breakpoints', () => {
     test('registered breakpoint fires onPause with arrivalPath', async () => {
       const pm = new PostMachine({
         10: check(20, 30),
@@ -633,7 +625,7 @@ describe('packages/machine/README.md', () => {
     });
   });
 
-  describe('Lockdown semantics (v6.1.0+)', () => {
+  describe('Lockdown semantics', () => {
     test('direct write on un-shared State redirects to setBreakpoint', () => {
       const pm = new PostMachine({ 10: mark, 20: stop });
 

--- a/packages/machine/src/classes/PostMachine.machine-state.spec.ts
+++ b/packages/machine/src/classes/PostMachine.machine-state.spec.ts
@@ -17,7 +17,7 @@ describe('PostMachine — wrapped MachineState', () => {
     }
   });
 
-  test('onIter receives arrivalPath and candidatePaths, once per iter (v6.4.0+)', async () => {
+  test('onIter receives arrivalPath and candidatePaths, once per iter', async () => {
     const m = new PostMachine({
       10: mark,
       20: stop,
@@ -68,11 +68,9 @@ describe('PostMachine — wrapped MachineState', () => {
   });
 
   test('subroutine body instruction has fully-qualified arrivalPath', async () => {
-    // Use a 2-instruction body so the second instruction is visited as its
-    // own iter (the first instruction's State is now the wrapper's bare
-    // under #85 — its arrivalPath is the call site, not the FQ subroutine
-    // path. The second body instruction always gets its own iter regardless
-    // of hopper-drop status).
+    // 2-instruction body so the second instruction visits as its own iter:
+    // the first instruction's State IS the wrapper's bare, so its
+    // arrivalPath is the call site (not the FQ subroutine path).
     const m = new PostMachine({
       10: call('foo'),
       foo: { 1: right, 2: mark },

--- a/packages/machine/src/classes/PostMachine.naming.spec.ts
+++ b/packages/machine/src/classes/PostMachine.naming.spec.ts
@@ -118,6 +118,8 @@ describe('PostMachine — group states and wrapper composite', () => {
   });
 });
 
+// Hopper-drop spec (#85): acyclic subroutines with a plain first instruction
+// skip the hopper and wrap their first-instruction State directly.
 describe('PostMachine — subroutine body and hopper names', () => {
   test('subroutine inner states use fully-qualified names', () => {
     // Use mark/right/mark so all three instructions produce real (non-halt) states.
@@ -129,8 +131,7 @@ describe('PostMachine — subroutine body and hopper names', () => {
         3: mark,
       },
     });
-    // Acyclic subroutine + plain first instruction → hopper dropped (#85).
-    // The wrapper's bare is foo's first-instruction State (foo::1) directly;
+    // Wrapper's bare is foo's first-instruction State (foo::1) directly;
     // composite name reflects that.
     expect(machine.initialState.name).toBe('foo::1(10~halt)');
 
@@ -139,7 +140,7 @@ describe('PostMachine — subroutine body and hopper names', () => {
     expect(names.has('foo::1')).toBe(true);
     expect(names.has('foo::2')).toBe(true);
     expect(names.has('foo::3')).toBe(true);
-    // Hopper dropped — no bare 'foo' node in the graph.
+    // No bare 'foo' node in the graph.
     expect(names.has('foo')).toBe(false);
   });
 
@@ -155,7 +156,7 @@ describe('PostMachine — subroutine body and hopper names', () => {
       },
     });
     // outer's first instruction is `call('inner')` — that produces a wrapper,
-    // so #85's hopper-drop is blocked (engine #176 would unwrap the inner
+    // so the hopper-drop is blocked (engine #176 would unwrap the inner
     // wrapping). outer keeps its hopper named "outer".
     expect(machine.initialState.name).toBe('outer(10~halt)');
 
@@ -183,10 +184,9 @@ describe('PostMachine — combined naming scenarios', () => {
       },
     });
     const names = collectNames(machine);
-    // Under #85, `bar` is acyclic + plain first instruction (mark) → hopper
-    // dropped; no bare 'foo::bar' node. The inner-call wrapper composite is
-    // 'foo::bar::1(foo::1~foo::2)' on state.name, with body state 'foo::bar::1'
-    // appearing as a node.
+    // `bar` is acyclic + plain first instruction → no bare 'foo::bar' node.
+    // The inner-call wrapper composite is 'foo::bar::1(foo::1~foo::2)' on
+    // state.name, with body state 'foo::bar::1' appearing as a node.
     expect(names.has('foo::bar')).toBe(false);
     expect(names.has('foo::bar::1')).toBe(true);
     expect(names.has('foo::1~foo::2')).toBe(true);
@@ -219,9 +219,9 @@ describe('PostMachine — combined naming scenarios', () => {
       },
     });
     const names = collectNames(machine);
-    // Under #85, `bar` is acyclic + plain first instruction → hopper dropped.
-    // No bare 'foo::bar' node; the bare 'foo::bar::1' is the wrapper's target,
-    // and the tail-position continuation is 'foo::1~halt'.
+    // `bar` is acyclic + plain first instruction → no bare 'foo::bar' node.
+    // The bare 'foo::bar::1' is the wrapper's target; tail continuation
+    // is 'foo::1~halt'.
     expect(names.has('foo::bar')).toBe(false);
     expect(names.has('foo::1~halt')).toBe(true);
     expect(names.has('foo::bar::1')).toBe(true);
@@ -240,9 +240,9 @@ describe('PostMachine — combined naming scenarios', () => {
       },
     });
     const names = collectNames(machine);
-    // Each scope hops accumulate in the prefix. `deepest` is acyclic with a
-    // plain first instruction → hopper dropped (#85); only its body state
-    // 'outer::inner::deepest::1' appears in the graph.
+    // Each scope hop accumulates in the prefix. `deepest` is acyclic with
+    // a plain first instruction — no bare 'outer::inner::deepest' node,
+    // only its body state 'outer::inner::deepest::1' appears.
     expect(names.has('outer::inner::deepest::1')).toBe(true);
     expect(names.has('outer::inner::deepest')).toBe(false);
   });

--- a/packages/machine/src/classes/PostMachine.spec.ts
+++ b/packages/machine/src/classes/PostMachine.spec.ts
@@ -232,10 +232,8 @@ describe('constructor', () => {
       .toThrow(`invalid subroutine name: '${invalidSubroutineName}'`);
   });
 
-  // Regression: the regex used to be unanchored (/[A-Z$_][A-Z0-9$_]*/i),
-  // accepting any string CONTAINING a valid identifier substring. After the
-  // ^...$ anchor fix, leading-digit and embedded-space names are correctly
-  // rejected.
+  // Regression: subroutine-name regex must be fully anchored — reject
+  // leading-digit and embedded-space names.
   describe('subroutineNameValidator anchor regression', () => {
     ['1abc', 'foo bar', '$$ x', 'a/b', '!name'].forEach((name) => {
       test(`rejects ${JSON.stringify(name)}`, () => {
@@ -465,12 +463,9 @@ describe('run tests', () => {
         stepsLimit: 3,
         onStep: (...args) => onStepMock3(...args),
       })).resolves.toBeUndefined();
-      // Under #85, the subroutine's hopper is dropped (acyclic + plain first
-      // instruction noop). The previous "iter 1: hopper, iter 2: noop body,
-      // iter 3: halt" sequence collapses to "iter 1: wrapper-of-noop, iter 2:
-      // halt" — one fewer onStep call per machine. (Note: post-iter halt
-      // dispatches as the second call here because the wrapper-of-noop's
-      // halt-bound transition resolves to haltState directly.)
+      // 2 iters: wrapper-of-noop fires once, then post-iter halt dispatch.
+      // (Acyclic + plain-first-instruction subroutine wraps the body directly,
+      // no hopper iter.)
       expect(onStepMock1).toHaveBeenCalledTimes(2);
       expect(onStepMock2).toHaveBeenCalledTimes(2);
       expect(onStepMock3).toHaveBeenCalledTimes(2);
@@ -587,13 +582,11 @@ describe('run tests', () => {
       onStep: (...args) => onStepMock(...args),
     })).resolves.toBeUndefined();
 
-    // Under #85, hoppers are dropped for `subroutineNameList[1]` (outer,
-    // first instr `mark`, acyclic) and the nested `subroutineNameList[0]`
-    // (first instr `erase`, acyclic). Outer `subroutineNameList[0]` keeps
-    // its hopper (the analyzer sees its body calling 'sub0' as a lexical
-    // self-reference, conservatively classifying it as cyclic — runtime
-    // would resolve through shadowing, but the static analyzer doesn't
-    // model scope shadowing). Net: 2 fewer onStep calls than v6.x's 8.
+    // Outer `subroutineNameList[0]` keeps its hopper — the static analyzer
+    // sees its body calling 'sub0' as a lexical self-reference and
+    // conservatively classifies it as cyclic (runtime would resolve through
+    // shadowing, but the analyzer doesn't model scope shadowing).
+    // The other two subs are acyclic + plain-first-instruction → no hopper.
     expect(onStepMock).toHaveBeenCalledTimes(6);
     expect(machine.tape.viewport[0]).toEqual(' ');
 

--- a/packages/machine/src/classes/PostMachine.ts
+++ b/packages/machine/src/classes/PostMachine.ts
@@ -116,14 +116,9 @@ export class PostMachine extends TuringMachine {
     let prevJsSymbol: symbol | null = null;
     const entryPath = this.#firstStepArrivalPath();
 
-    // Tracking is owned by the internal onIter wrapper (engine v6.4.0+).
-    // onIter fires at end-of-iter — after both onPause(before, K) and
-    // onPause(after, K) have already read their iter-correct prev — so
-    // advancing here doesn't race those reads. Previously this lived in
-    // the internal onStep wrapper, which ran BETWEEN before- and after-
-    // fires on the same yield, causing after-fire arrivalPath to resolve
-    // against K's prev instead of K-1's. See tests/breakpoints.spec.ts
-    // "arrivalPath in after-fire onPause" for the regression case.
+    // Advance at end-of-iter (via the internal onIter wrapper) so both
+    // `onPause(before, K)` and `onPause(after, K)` read iter-correct prev.
+    // Advancing inside onStep would race after-fire arrivalPath resolution.
     const advanceTracking = (raw: EngineMachineState): void => {
       prevState = raw.state;
       prevJsSymbol = this.tapeBlock.symbol([raw.currentSymbols[0]]);
@@ -281,19 +276,15 @@ export class PostMachine extends TuringMachine {
     };
     // Cycle-aware hopper construction (#85).
     //
-    // Static analysis of the local subroutine call graph identifies which
-    // subroutines participate in cycles (mutual recursion or self-loop). For
-    // those, we keep the v6.x hopper — a stub `State` that wraps a
-    // `Reference` to the subroutine's first instruction, providing the
-    // forward-declaration anchor that `withOverriddenHaltState` needs at the
-    // moment `call(...)` invocations are processed.
+    // Subroutines in cycles (mutual recursion / self-loop) get a hopper — a
+    // stub `State` wrapping a `Reference` to the first instruction — to give
+    // `withOverriddenHaltState` a forward-declaration anchor when `call(...)`
+    // is processed.
     //
-    // Acyclic subroutines (the common case) skip the hopper. We process them
-    // in reverse-topological build order — sinks first — so by the time
-    // `call('X')` runs for an acyclic X, X's first-instruction State already
-    // exists and we wrap it directly. Net effect: -1 graph node per acyclic
-    // subroutine; the wrapper composite name becomes `X::1(continuation)`
-    // (accurately reflects the wrapped bare) instead of `X(continuation)`.
+    // Acyclic subroutines skip the hopper: processed in reverse-topological
+    // build order, so by the time `call('X')` runs for acyclic X, X's
+    // first-instruction State already exists and we wrap it directly.
+    // Composite name reflects the wrapped bare: `X::1(continuation)`.
     const localSubroutineInstructions: Record<string, Instructions> = Object.fromEntries(
       Object.entries(localSubroutinesData).map(([name, data]) => [name, data.instructions]),
     );

--- a/packages/machine/src/index.ts
+++ b/packages/machine/src/index.ts
@@ -1,12 +1,6 @@
 import type { MachineState as EngineMachineState } from '@turing-machine-js/machine';
 import type { Path } from './path';
 
-// haltState is intentionally NOT locked down — direct
-// `haltState.debug = boolean` writes go to the engine
-// setter (turing-machine-js#207). Per-PostMachine
-// State lockdown is installed by PostMachine's
-// constructor (see `installStateLockdown`).
-
 export {
   Tape,
   State,

--- a/packages/machine/src/lockdown.spec.ts
+++ b/packages/machine/src/lockdown.spec.ts
@@ -76,9 +76,8 @@ describe('installStateLockdown', () => {
       // After the inner escape ends, the outer is still active.
       s.debug = null;
     });
-    // Engine v6.1+ (#150) returns an empty `DebugConfig` after `state.debug = null`
-    // (filters cleared) rather than literal `null`. Check the public getters
-    // directly — `undefined` is the "no filter set" sentinel.
+    // state.debug after a clear is an empty DebugConfig — read filter getters
+    // directly; `undefined` is the "no filter set" sentinel.
     expect(s.debug.before).toBeUndefined();
     expect(s.debug.after).toBeUndefined();
   });

--- a/packages/machine/src/lockdown.ts
+++ b/packages/machine/src/lockdown.ts
@@ -16,8 +16,8 @@ export function withLockdownEscape<T>(fn: () => T): T {
 }
 
 function captureProtoDebugAccessor(state: object): { get: () => unknown; set: (v: unknown) => void } {
-  // Engine v6: State.prototype owns `get debug() / set debug()`. The descriptor is
-  // always on the immediate prototype.
+  // State.prototype owns `get debug() / set debug()` — descriptor is on the
+  // immediate prototype.
   const proto = Object.getPrototypeOf(state);
   const desc = Object.getOwnPropertyDescriptor(proto, 'debug')!;
   return { get: desc.get!.bind(state), set: desc.set!.bind(state) };


### PR DESCRIPTION
## Summary

Audit pass on source comments. \"no historical bullshit in source — that belongs in commits/PRs/CHANGELOG.\" 11 files, -43 lines net.

Companion to engine [#212](https://github.com/mellonis/turing-machine-js/pull/212).

## Bucket 2 — actively wrong (fix-now)

- **\`callGraph.ts:97-98\`** — dropped comment referring to a non-existent \`extractCallTargets\` function (only the \`FromInstructions\` variant exists in the file).
- **\`PostMachine.debugger.spec.ts:1\`** — \`onPause\` is stable since v6.1.0, not \"experimental\". Also dropped \"Per turing v4\" qualifier on the debug-mutability note.
- **\`index.ts:4-8\`** — dropped \"haltState is intentionally NOT locked down\" framing — that was leftover residue from PR #94 explaining a non-feature.

## Bucket 1 — historical bloat (trim/drop)

- **\`lockdown.ts:19\`** — dropped \"Engine v6\" qualifier on the prototype-descriptor invariant
- **\`PostMachine.ts\`** — trimmed \`advanceTracking\` \"previously this lived in onStep\" paragraph + the cycle-aware-hopper \"v6.x hopper\" / \"Net effect\" framing
- **\`breakpoints.spec.ts\` + \`lockdown.spec.ts\`** — 3 \"Engine v6.1+ (#150) returned X rather than literal null\" framings; 14-line \"v6.1.0-v6.3.0 advanceTracking ordering bug ... Fixed in v6.4.0\" walkthrough
- **\`PostMachine.naming.spec.ts\`** — 6 \"Under #85 / v6.x hopper\" framings; added one #85 anchor at the describe block as the single forward-looking spec reference
- **\`PostMachine.examples.spec.ts\`** — \"engine v7's callable-subtree emit (#174) PLUS #85\" narrative, \"retired alpha.1 \`-. onHalt .->\` keyword\" reference, \"vs alpha.2's 7 with the hopper\" delta; 4 \`(v6.1.0+)\` describe-title suffixes
- **\`PostMachine.spec.ts\`** — \"Under #85 ... previously 'iter 1: hopper' sequence collapses\" delta + \"Net: 2 fewer than v6.x's 8\" delta
- **\`PostMachine.machine-state.spec.ts\`** — \`(v6.4.0+)\` test-name suffix + \"under #85\" mid-sentence qualifier

## What I kept

- Forward-looking issue refs (\`#85\`, \`#174\`, \`#207\`, etc. AS ANCHORS for current spec)
- Non-obvious-invariant notes (e.g. the static-analyzer scope-shadowing surprise in PostMachine.spec.ts)
- All test assertion behavior unchanged

## Test plan

- [x] \`npm test\` — 315/315 passing
- [x] \`npm run lint\` — clean
- [x] \`npx tsc --build\` — clean
- [ ] CI green on PR

After this merges, ready to resume the post alpha.5 release pipeline.