### PR TITLE
adopt(post): engine v7.0.0-alpha.6 DebugSession reshape (#97)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2740,9 +2740,9 @@
       }
     },
     "node_modules/@turing-machine-js/machine": {
-      "version": "7.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.5.tgz",
-      "integrity": "sha512-OxVwi89HxvTc3H+YzBGfB6cSXkRWdkOL77T6sCAKkCn82Nxq8oTGcQUWLOR0+23s65rcpUflMQZbabtJzN5BXA==",
+      "version": "7.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@turing-machine-js/machine/-/machine-7.0.0-alpha.6.tgz",
+      "integrity": "sha512-xHlFzcKE1e6YUeYYua3seu59it8HElbOsxBPDzhpwTmixpOgrZgSB3ENs3KaisgEdROSaytlZw/6udWYQ2lj+w==",
       "license": "GPL-3.0-or-later",
       "engines": {
         "npm": ">=7.0.0"

--- a/packages/machine/src/breakpoints.spec.ts
+++ b/packages/machine/src/breakpoints.spec.ts
@@ -203,7 +203,9 @@ describe('onPause — registry-aware filtering', () => {
     pm.replaceTapeWith(new Tape({ alphabet: pm.tape.alphabet, symbols: ['*', '*', ' '] }));
     pm.setBreakpoint('30', { before: true });
     const paused: number[] = [];
-    await pm.run({ onPause: (s) => { paused.push(s.arrivalPath.instructionIndex); } });
+    const session = pm.debugRun();
+    session.on('pause', (s) => { paused.push(s.arrivalPath.instructionIndex); session.continue(); });
+    await session.start();
     expect(paused).toContain(30);
     pm.clearBreakpoints();
   });
@@ -224,7 +226,9 @@ describe('onPause — registry-aware filtering', () => {
     pm.replaceTapeWith(new Tape({ alphabet: pm.tape.alphabet, symbols: ['*', '*', ' '] }));
     pm.setBreakpoint('30', { after: true });
     const paused: number[] = [];
-    await pm.run({ onPause: (s) => { paused.push(s.arrivalPath.instructionIndex); } });
+    const session = pm.debugRun();
+    session.on('pause', (s) => { paused.push(s.arrivalPath.instructionIndex); session.continue(); });
+    await session.start();
     expect(paused).toEqual([30]);
     pm.clearBreakpoints();
   });
@@ -243,7 +247,9 @@ describe('onPause — registry-aware filtering', () => {
     // but PostMachine's wrapper sees arrival=10, no registered match → silent.
     pm.setBreakpoint('30', { before: true });
     const paused: number[] = [];
-    await pm.run({ onPause: (s) => { paused.push(s.arrivalPath.instructionIndex); } });
+    const session = pm.debugRun();
+    session.on('pause', (s) => { paused.push(s.arrivalPath.instructionIndex); session.continue(); });
+    await session.start();
     expect(paused).toEqual([]);
     pm.clearBreakpoints();
   });
@@ -259,7 +265,9 @@ describe('onPause — registry-aware filtering', () => {
     pm.replaceTapeWith(new Tape({ alphabet: pm.tape.alphabet, symbols: ['*', '*', ' '] }));
     pm.setBreakpoint(haltState, { before: true });
     const paused: number[] = [];
-    await pm.run({ onPause: () => { paused.push(1); } });
+    const session = pm.debugRun();
+    session.on('pause', () => { paused.push(1); session.continue(); });
+    await session.start();
     expect(paused.length).toBeGreaterThan(0);
     pm.clearBreakpoints();
   });

--- a/packages/machine/src/classes/PostDebugSession.ts
+++ b/packages/machine/src/classes/PostDebugSession.ts
@@ -1,0 +1,169 @@
+import {
+  DebugSession as EngineDebugSession,
+  type MachineState as EngineMachineState,
+  State,
+  haltState,
+} from '@turing-machine-js/machine';
+import { formatPath, type Path } from '../path';
+import type { MachineState } from '../index';
+import type { Breakpoint } from '../breakpoints';
+import type { PostMachine } from './PostMachine';
+
+export type PostDebugSessionEvent = 'pause' | 'step' | 'iter' | 'halt';
+
+export type PostDebugSessionListener<E extends PostDebugSessionEvent> =
+  E extends 'halt'
+    ? () => void | Promise<void>
+    : (machineState: MachineState) => void | Promise<void>;
+
+type ListenerMap = {
+  pause: Array<(m: MachineState) => void | Promise<void>>;
+  step: Array<(m: MachineState) => void | Promise<void>>;
+  iter: Array<(m: MachineState) => void | Promise<void>>;
+  halt: Array<() => void | Promise<void>>;
+};
+
+export type PostDebugSessionParameter = {
+  stepsLimit?: number;
+};
+
+/**
+ * Interactive debugger session for `PostMachine`. Wraps the upstream engine
+ * `DebugSession`, adds post-specific MachineState wrapping (`arrivalPath`,
+ * `candidatePaths`), and applies the PostMachine's breakpoint registry as a
+ * filter before forwarding pause events.
+ *
+ * Construct via `pm.debugRun()` rather than instantiating directly — the
+ * factory wires up the prev-state tracking and registry reference.
+ */
+export class PostDebugSession {
+  readonly #postMachine: PostMachine;
+  readonly #engineSession: EngineDebugSession;
+  readonly #listeners: ListenerMap = {
+    pause: [],
+    step: [],
+    iter: [],
+    halt: [],
+  };
+  #prevState: State | null = null;
+  #prevJsSymbol: symbol | null = null;
+  readonly #entryPath: Path;
+  readonly #wrap: (raw: EngineMachineState, prev: State | null, prevSym: symbol | null) => MachineState;
+  readonly #getBreakpoints: () => readonly Breakpoint[];
+  readonly #tapeBlockSymbol: (pattern: [string]) => symbol;
+
+  constructor(args: {
+    postMachine: PostMachine;
+    engineSession: EngineDebugSession;
+    entryPath: Path;
+    wrap: (raw: EngineMachineState, prev: State | null, prevSym: symbol | null) => MachineState;
+    getBreakpoints: () => readonly Breakpoint[];
+    tapeBlockSymbol: (pattern: [string]) => symbol;
+  }) {
+    this.#postMachine = args.postMachine;
+    this.#engineSession = args.engineSession;
+    this.#entryPath = args.entryPath;
+    this.#wrap = args.wrap;
+    this.#getBreakpoints = args.getBreakpoints;
+    this.#tapeBlockSymbol = args.tapeBlockSymbol;
+
+    // Wire engine events to wrap + dispatch via our own listener registry.
+    this.#engineSession.on('step', (raw) => {
+      const wrapped = this.#wrap(raw, this.#prevState, this.#prevJsSymbol);
+      for (const fn of this.#listeners.step) void fn(wrapped);
+    });
+    this.#engineSession.on('pause', (raw) => {
+      const wrapped = this.#wrap(raw, this.#prevState, this.#prevJsSymbol);
+      // Apply post-machine breakpoint registry filter — fire only when the
+      // engine pause was triggered by a registered breakpoint (or by a
+      // step-mode endpoint / manual pause).
+      if (!this.#shouldFire(raw, wrapped)) {
+        this.#engineSession.continue();
+        return;
+      }
+      for (const fn of this.#listeners.pause) void fn(wrapped);
+    });
+    this.#engineSession.on('iter', (raw) => {
+      const wrapped = this.#wrap(raw, this.#prevState, this.#prevJsSymbol);
+      for (const fn of this.#listeners.iter) void fn(wrapped);
+      // Advance prev for the NEXT iter's wrapping.
+      this.#prevState = raw.state;
+      this.#prevJsSymbol = this.#tapeBlockSymbol([raw.currentSymbols[0]]);
+    });
+    this.#engineSession.on('halt', () => {
+      for (const fn of this.#listeners.halt) void fn();
+    });
+
+    // Touch unused fields to satisfy the noUnusedLocals heuristic — they exist
+    // for future wrappers that need to read them.
+    void this.#postMachine;
+    void this.#entryPath;
+  }
+
+  on<E extends PostDebugSessionEvent>(event: E, listener: PostDebugSessionListener<E>): this {
+    (this.#listeners[event] as Array<PostDebugSessionListener<E>>).push(listener);
+    return this;
+  }
+
+  off<E extends PostDebugSessionEvent>(event: E, listener: PostDebugSessionListener<E>): this {
+    const arr = this.#listeners[event] as Array<PostDebugSessionListener<E>>;
+    const ix = arr.indexOf(listener);
+    if (ix >= 0) arr.splice(ix, 1);
+    return this;
+  }
+
+  start(): Promise<void> {
+    return this.#engineSession.start();
+  }
+
+  stop(): void {
+    this.#engineSession.stop();
+  }
+
+  pause(): void {
+    this.#engineSession.pause();
+  }
+
+  continue(): void {
+    this.#engineSession.continue();
+  }
+
+  stepIn(): void {
+    this.#engineSession.stepIn();
+  }
+
+  stepOver(): void {
+    this.#engineSession.stepOver();
+  }
+
+  stepOut(): void {
+    this.#engineSession.stepOut();
+  }
+
+  setRunInterval(ms: number): void {
+    this.#engineSession.setRunInterval(ms);
+  }
+
+  // Decide whether a raw engine pause should surface to post-machine pause
+  // listeners. Step-mode endpoints and manual pauses always pass through;
+  // breakpoint-cause pauses are filtered against the registry so only
+  // path-registered or halt-registered states fire.
+  #shouldFire(raw: EngineMachineState, wrapped: MachineState): boolean {
+    const cause = raw.debugBreak?.cause;
+    if (cause === 'step' || cause === 'manual') {
+      return true;
+    }
+    // cause: 'breakpoint' — apply registry filter.
+    const breakpoints = this.#getBreakpoints();
+    const nextIsHalt = raw.nextState instanceof State && raw.nextState.isHalt;
+    if (nextIsHalt && breakpoints.some((bp) => bp.kind === 'halt')) {
+      return true;
+    }
+    const arrivalKey = formatPath(wrapped.arrivalPath);
+    return breakpoints.some((bp) =>
+      bp.kind === 'instruction' && formatPath(bp.path) === arrivalKey);
+  }
+}
+
+// Re-exported to keep import surfaces tight at the package boundary.
+export { haltState };

--- a/packages/machine/src/classes/PostDebugSession.ts
+++ b/packages/machine/src/classes/PostDebugSession.ts
@@ -1,6 +1,8 @@
 import {
   DebugSession as EngineDebugSession,
   type MachineState as EngineMachineState,
+  type PauseInfo,
+  type PausedMachineState as EnginePausedMachineState,
   State,
   haltState,
 } from '@turing-machine-js/machine';
@@ -11,13 +13,19 @@ import type { PostMachine } from './PostMachine';
 
 export type PostDebugSessionEvent = 'pause' | 'step' | 'iter' | 'halt';
 
+/** A post-wrapped `MachineState` (arrivalPath / candidatePaths) plus the
+ *  engine's one-sided pause descriptor — the payload of a `pause` event. */
+export type PostPausedMachineState = MachineState & { pause: PauseInfo };
+
 export type PostDebugSessionListener<E extends PostDebugSessionEvent> =
   E extends 'halt'
     ? () => void | Promise<void>
-    : (machineState: MachineState) => void | Promise<void>;
+    : E extends 'pause'
+      ? (machineState: PostPausedMachineState) => void | Promise<void>
+      : (machineState: MachineState) => void | Promise<void>;
 
 type ListenerMap = {
-  pause: Array<(m: MachineState) => void | Promise<void>>;
+  pause: Array<(m: PostPausedMachineState) => void | Promise<void>>;
   step: Array<(m: MachineState) => void | Promise<void>>;
   iter: Array<(m: MachineState) => void | Promise<void>>;
   halt: Array<() => void | Promise<void>>;
@@ -73,7 +81,12 @@ export class PostDebugSession {
       for (const fn of this.#listeners.step) void fn(wrapped);
     });
     this.#engineSession.on('pause', (raw) => {
-      const wrapped = this.#wrap(raw, this.#prevState, this.#prevJsSymbol);
+      // raw is the engine's PausedMachineState — carry its `pause` descriptor
+      // onto the post-wrapped state so post pause listeners see {side, cause}.
+      const wrapped: PostPausedMachineState = {
+        ...this.#wrap(raw, this.#prevState, this.#prevJsSymbol),
+        pause: raw.pause,
+      };
       // Apply post-machine breakpoint registry filter — fire only when the
       // engine pause was triggered by a registered breakpoint (or by a
       // step-mode endpoint / manual pause).
@@ -148,8 +161,8 @@ export class PostDebugSession {
   // listeners. Step-mode endpoints and manual pauses always pass through;
   // breakpoint-cause pauses are filtered against the registry so only
   // path-registered or halt-registered states fire.
-  #shouldFire(raw: EngineMachineState, wrapped: MachineState): boolean {
-    const cause = raw.debugBreak?.cause;
+  #shouldFire(raw: EnginePausedMachineState, wrapped: MachineState): boolean {
+    const cause = raw.pause.cause;
     if (cause === 'step' || cause === 'manual') {
       return true;
     }

--- a/packages/machine/src/classes/PostMachine.debugger.spec.ts
+++ b/packages/machine/src/classes/PostMachine.debugger.spec.ts
@@ -28,11 +28,11 @@ describe('PostMachine — async run', () => {
     }));
 
     const result = machine.run();
-    expect(result).toBeInstanceOf(Promise);
-    return result; // ensure jest waits for halt
+    // v7: run() is sync, returns void.
+    expect(result).toBeUndefined();
   });
 
-  test('run() resolves only after the machine halts', async () => {
+  test('run() is synchronous — tape is final immediately after the call', () => {
     const machine = buildWalkAndMark();
 
     machine.replaceTapeWith(new Tape({
@@ -40,10 +40,10 @@ describe('PostMachine — async run', () => {
       symbols: ['*', '*', ' '],
     }));
 
-    // Before run resolves, the tape should be the input.
+    // Before run runs, the tape should be the input.
     expect(machine.tape.symbols.join('').trim()).toBe('**');
 
-    await machine.run();
+    machine.run();
 
     expect(machine.tape.symbols.join('').trim()).toBe('***');
   });
@@ -57,9 +57,7 @@ describe('PostMachine — async run', () => {
     }));
 
     const seen: number[] = [];
-    await machine.run({
-      onStep: (s: MachineState) => { seen.push(s.step); },
-    });
+    for (const s of machine.runStepByStep()) { seen.push(s.step); }
 
     expect(seen.length).toBeGreaterThan(0);
     // Steps are 1-indexed and monotonically increasing.
@@ -87,12 +85,12 @@ describe('PostMachine — onPause forwarding', () => {
     machine.initialState.debug = { before: true };
 
     const seen: MachineState[] = [];
-    await machine.run({
-      onPause: (s) => { seen.push(s); },
-    });
+    const session = machine.debugRun();
+    session.on('pause', (s) => { seen.push(s); session.continue(); });
+    await session.start();
 
     expect(seen.length).toBeGreaterThan(0);
-    expect(seen[0].debugBreak).toEqual({ before: true });
+    expect(seen[0].debugBreak).toEqual({ before: true, cause: 'breakpoint' });
   });
 
   test('run() awaits an async onPause before resolving', async () => {
@@ -111,14 +109,15 @@ describe('PostMachine — onPause forwarding', () => {
     machine.initialState.debug = { before: true };
 
     let asyncCallbackResolved = false;
-    await machine.run({
-      onPause: async () => {
-        await new Promise((r) => setTimeout(r, 10));
-        asyncCallbackResolved = true;
-      },
+    const session = machine.debugRun();
+    session.on('pause', async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      asyncCallbackResolved = true;
+      session.continue();
     });
+    await session.start();
 
-    // If run() resolved before the async callback finished, this would be false.
+    // If start() resolved before the async callback finished, this would be false.
     expect(asyncCallbackResolved).toBe(true);
   });
 });

--- a/packages/machine/src/classes/PostMachine.debugger.spec.ts
+++ b/packages/machine/src/classes/PostMachine.debugger.spec.ts
@@ -5,7 +5,6 @@
 import {
   PostMachine,
   Tape,
-  type MachineState,
   check, mark, right, stop,
 } from '../index';
 

--- a/packages/machine/src/classes/PostMachine.debugger.spec.ts
+++ b/packages/machine/src/classes/PostMachine.debugger.spec.ts
@@ -84,13 +84,13 @@ describe('PostMachine — onPause forwarding', () => {
     // runtime-mutable; the upstream run() loop checks it on each iter.
     machine.initialState.debug = { before: true };
 
-    const seen: MachineState[] = [];
+    const seen: Array<{side: string; cause: string}> = [];
     const session = machine.debugRun();
-    session.on('pause', (s) => { seen.push(s); session.continue(); });
+    session.on('pause', (s) => { seen.push({side: s.pause.side, cause: s.pause.cause}); session.continue(); });
     await session.start();
 
     expect(seen.length).toBeGreaterThan(0);
-    expect(seen[0].debugBreak).toEqual({ before: true, cause: 'breakpoint' });
+    expect(seen[0]).toEqual({ side: 'before', cause: 'breakpoint' });
   });
 
   test('run() awaits an async onPause before resolving', async () => {

--- a/packages/machine/src/classes/PostMachine.examples.spec.ts
+++ b/packages/machine/src/classes/PostMachine.examples.spec.ts
@@ -354,12 +354,10 @@ describe('packages/machine/README.md', () => {
       });
 
       const steps: { arrivalPath: Path; candidatePaths: Path[] }[] = [];
-      await m.run({
-        onStep: (s: MachineState) => {
-          // console.log('at:', s.arrivalPath, 'shared with:', s.candidatePaths);
-          steps.push({ arrivalPath: s.arrivalPath, candidatePaths: s.candidatePaths });
-        },
-      });
+      for (const s of m.runStepByStep()) {
+        // console.log('at:', s.arrivalPath, 'shared with:', s.candidatePaths);
+        steps.push({ arrivalPath: s.arrivalPath, candidatePaths: s.candidatePaths });
+      }
 
       // onStep fires once — for the `mark` transition at instruction 10.
       expect(steps).toHaveLength(1);
@@ -601,11 +599,12 @@ describe('packages/machine/README.md', () => {
       pm.setBreakpoint('30', { before: true });
 
       const paused: number[] = [];
-      await pm.run({
-        onPause: (m: MachineState) => {
-          paused.push(m.arrivalPath.instructionIndex);
-        },
+      const session = pm.debugRun();
+      session.on('pause', (m: MachineState) => {
+        paused.push(m.arrivalPath.instructionIndex);
+        session.continue();
       });
+      await session.start();
 
       expect(paused).toContain(30);
     });

--- a/packages/machine/src/classes/PostMachine.machine-state.spec.ts
+++ b/packages/machine/src/classes/PostMachine.machine-state.spec.ts
@@ -9,7 +9,7 @@ describe('PostMachine — wrapped MachineState', () => {
       20: stop,
     });
     const seen: MachineState[] = [];
-    await m.run({ onStep: (s) => { seen.push(s); } });
+    for (const s of m.runStepByStep()) { seen.push(s); }
     expect(seen.length).toBeGreaterThan(0);
     for (const s of seen) {
       expect(s.arrivalPath).toBeDefined();
@@ -23,7 +23,7 @@ describe('PostMachine — wrapped MachineState', () => {
       20: stop,
     });
     const seen: MachineState[] = [];
-    await m.run({ onIter: async (s) => { seen.push(s); } });
+    for (const s of m.runStepByStep()) { seen.push(s); }
     expect(seen.length).toBeGreaterThan(0);
     for (const s of seen) {
       expect(s.arrivalPath).toBeDefined();
@@ -39,7 +39,7 @@ describe('PostMachine — wrapped MachineState', () => {
       20: stop,
     });
     const seen: MachineState[] = [];
-    await m.run({ onStep: (s) => { seen.push(s); } });
+    for (const s of m.runStepByStep()) { seen.push(s); }
     expect(seen[0].arrivalPath).toEqual(parsePath('10'));
   });
 
@@ -49,7 +49,7 @@ describe('PostMachine — wrapped MachineState', () => {
       20: stop,
     });
     const seen: MachineState[] = [];
-    await m.run({ onStep: (s) => { seen.push(s); } });
+    for (const s of m.runStepByStep()) { seen.push(s); }
     expect(seen[0].candidatePaths).toEqual([parsePath('10')]);
   });
 
@@ -62,7 +62,7 @@ describe('PostMachine — wrapped MachineState', () => {
       30: stop,
     });
     const seen: MachineState[] = [];
-    await m.run({ onStep: (s) => { seen.push(s); } });
+    for (const s of m.runStepByStep()) { seen.push(s); }
     expect(seen[0].candidatePaths.length).toBe(2);
     expect(seen[0].candidatePaths.map(p => p.instructionIndex)).toEqual([10, 20]);
   });
@@ -76,7 +76,7 @@ describe('PostMachine — wrapped MachineState', () => {
       foo: { 1: right, 2: mark },
     });
     const seen: MachineState[] = [];
-    await m.run({ onStep: (s) => { seen.push(s); } });
+    for (const s of m.runStepByStep()) { seen.push(s); }
     // After the call wrapper executes foo::1, control reaches foo::2.
     const fooStep = seen.find(s => {
       const scope = s.arrivalPath.scope;
@@ -90,7 +90,7 @@ describe('PostMachine — wrapped MachineState', () => {
       50: [right, mark],
     });
     const seen: MachineState[] = [];
-    await m.run({ onStep: (s) => { seen.push(s); } });
+    for (const s of m.runStepByStep()) { seen.push(s); }
     // The second inner (mark) fires at 50.2 — the first inner (right) is wrapped
     // by withOverriddenHaltState and therefore resolves to the outer group path {50}
     // rather than {50.1}. The second inner state is unambiguously tagged 50.2.

--- a/packages/machine/src/classes/PostMachine.spec.ts
+++ b/packages/machine/src/classes/PostMachine.spec.ts
@@ -385,7 +385,7 @@ describe('run tests', () => {
 
     const exactStepCount = 49;
 
-    await machine.run({ stepsLimit: exactStepCount, onStep: () => onStepMock() });
+    for (const _ of machine.runStepByStep({ stepsLimit: exactStepCount })) { void _; onStepMock(); }
 
     expect(machine.tape.symbols.join('').trim()).toBe('****');
     expect(onStepMock).toHaveBeenCalledTimes(exactStepCount);
@@ -411,9 +411,9 @@ describe('run tests', () => {
         const onStepMock2 = vi.fn();
         const onStepMock3 = vi.fn();
 
-        await expect(machine1.run({ stepsLimit: 1, onStep: (stepData) => onStepMock1(stepData) })).resolves.toBeUndefined();
-        await expect(machine2.run({ stepsLimit: 1, onStep: (stepData) => onStepMock2(stepData) })).resolves.toBeUndefined();
-        await expect(machine3.run({ stepsLimit: 1, onStep: (stepData) => onStepMock3(stepData) })).resolves.toBeUndefined();
+        for (const s of machine1.runStepByStep({ stepsLimit: 1 })) onStepMock1(s);
+        for (const s of machine2.runStepByStep({ stepsLimit: 1 })) onStepMock2(s);
+        for (const s of machine3.runStepByStep({ stepsLimit: 1 })) onStepMock3(s);
         expect(onStepMock1).toHaveBeenCalledTimes(1);
         expect(onStepMock2).toHaveBeenCalledTimes(1);
         expect(onStepMock3).toHaveBeenCalledTimes(1);
@@ -451,18 +451,9 @@ describe('run tests', () => {
       const onStepMock2 = vi.fn();
       const onStepMock3 = vi.fn();
 
-      await expect(machine1.run({
-        stepsLimit: 3,
-        onStep: (...args) => onStepMock1(...args),
-      })).resolves.toBeUndefined();
-      await expect(machine2.run({
-        stepsLimit: 3,
-        onStep: (...args) => onStepMock2(...args),
-      })).resolves.toBeUndefined();
-      await expect(machine3.run({
-        stepsLimit: 3,
-        onStep: (...args) => onStepMock3(...args),
-      })).resolves.toBeUndefined();
+      for (const s of machine1.runStepByStep({ stepsLimit: 3 })) onStepMock1(s);
+      for (const s of machine2.runStepByStep({ stepsLimit: 3 })) onStepMock2(s);
+      for (const s of machine3.runStepByStep({ stepsLimit: 3 })) onStepMock3(s);
       // 2 iters: wrapper-of-noop fires once, then post-iter halt dispatch.
       // (Acyclic + plain-first-instruction subroutine wraps the body directly,
       // no hopper iter.)
@@ -490,7 +481,7 @@ describe('run tests', () => {
         [ixList[3]]: call(subroutineName),
       });
 
-      await expect(machine.run()).resolves.toBeUndefined();
+      expect(() => machine.run()).not.toThrow();
 
       expect(machine.tape.symbols.join('').trim())
         .toBe('***');
@@ -548,7 +539,7 @@ describe('run tests', () => {
           alphabet: machine.tape.alphabet,
           symbols: '***  *'.split(''),
         }));
-        await expect(machine.run()).resolves.toBeUndefined();
+        expect(() => machine.run()).not.toThrow();
       }
       expect(machineList.map((machine) => machine.tape.symbols.join('').trim()))
         .toEqual(machineList.map((_, ix) => (
@@ -578,9 +569,7 @@ describe('run tests', () => {
 
     const onStepMock = vi.fn();
 
-    await expect(machine.run({
-      onStep: (...args) => onStepMock(...args),
-    })).resolves.toBeUndefined();
+    for (const s of machine.runStepByStep()) onStepMock(s);
 
     // Outer `subroutineNameList[0]` keeps its hopper — the static analyzer
     // sees its body calling 'sub0' as a lexical self-reference and
@@ -615,15 +604,12 @@ describe('run tests', () => {
         const machine1OnStepMock = vi.fn();
         const machine2OnStepMock = vi.fn();
 
-        await expect(machine1.run({
-          stepsLimit: 3,
-          onStep: (...args) => machine1OnStepMock(...args),
-        })).rejects.toThrow('Long execution');
-
-        await expect(machine2.run({
-          stepsLimit: 3,
-          onStep: (...args) => machine2OnStepMock(...args),
-        })).rejects.toThrow('Long execution');
+        expect(() => {
+          for (const s of machine1.runStepByStep({ stepsLimit: 3 })) machine1OnStepMock(s);
+        }).toThrow('Long execution');
+        expect(() => {
+          for (const s of machine2.runStepByStep({ stepsLimit: 3 })) machine2OnStepMock(s);
+        }).toThrow('Long execution');
 
         const machine1StateIdList = machine1OnStepMock.mock.calls.map((args) => args[0].state.id);
         const machine2StateIdList = machine2OnStepMock.mock.calls.map((args) => args[0].state.id);
@@ -660,15 +646,12 @@ describe('run tests', () => {
       const machine1OnStepMock = vi.fn();
       const machine2OnStepMock = vi.fn();
 
-      await expect(machine1.run({
-        stepsLimit: 10,
-        onStep: (...args) => machine1OnStepMock(...args),
-      })).rejects.toThrow('Long execution');
-
-      await expect(machine2.run({
-        stepsLimit: 10,
-        onStep: (...args) => machine2OnStepMock(...args),
-      })).rejects.toThrow('Long execution');
+      expect(() => {
+        for (const s of machine1.runStepByStep({ stepsLimit: 10 })) machine1OnStepMock(s);
+      }).toThrow('Long execution');
+      expect(() => {
+        for (const s of machine2.runStepByStep({ stepsLimit: 10 })) machine2OnStepMock(s);
+      }).toThrow('Long execution');
 
       const regExp = /\(/;
       const machine1StateIdList = machine1OnStepMock.mock.calls
@@ -698,10 +681,9 @@ describe('run tests', () => {
       });
       const machineOnStepMock = vi.fn();
 
-      await expect(machine.run({
-        stepsLimit: 10,
-        onStep: (...args) => machineOnStepMock(...args),
-      })).rejects.toThrow('Long execution');
+      expect(() => {
+        for (const s of machine.runStepByStep({ stepsLimit: 10 })) machineOnStepMock(s);
+      }).toThrow('Long execution');
 
       const machine1StateIdList = machineOnStepMock.mock.calls
         .map((args) => args[0].state.id);
@@ -840,7 +822,7 @@ describe('run tests', () => {
         [ixList[2]]: erase,
       });
 
-      await expect(machine.run()).resolves.toBeUndefined();
+      expect(() => machine.run()).not.toThrow();
 
       expect(machine.tape.symbols.join('').trim())
         .toBe('**');
@@ -861,7 +843,7 @@ describe('run tests', () => {
         ],
       });
 
-      await expect(machine.run()).resolves.toBeUndefined();
+      expect(() => machine.run()).not.toThrow();
 
       expect(machine.tape.symbols.join('').trim())
         .toBe('* *');

--- a/packages/machine/src/classes/PostMachine.ts
+++ b/packages/machine/src/classes/PostMachine.ts
@@ -188,7 +188,17 @@ export class PostMachine extends TuringMachine {
       }
     }
     const candidatePaths = this.#stateToCandidatePaths.get(raw.state) ?? [];
-    return { ...raw, arrivalPath, candidatePaths } as MachineState;
+    // Attach post fields IN PLACE rather than spreading into a new object. The
+    // engine stamps a non-enumerable `MACHINE_STATE_INTERNAL` Symbol accessor
+    // on each yield (halt-stack + matched symbol + halt-imminence) that the
+    // engine's DebugSession reads for breakpoint detection. A spread
+    // (`{...raw}`) silently drops that Symbol — and it's package-private, so
+    // we can't re-attach it. Mutating `raw` (a fresh per-iter object the engine
+    // doesn't retain) preserves the accessor while adding our fields.
+    const wrapped = raw as MachineState;
+    wrapped.arrivalPath = arrivalPath;
+    wrapped.candidatePaths = candidatePaths;
+    return wrapped;
   }
 
   #buildInitialState({

--- a/packages/machine/src/classes/PostMachine.ts
+++ b/packages/machine/src/classes/PostMachine.ts
@@ -1,5 +1,6 @@
 import {
   Alphabet,
+  DebugSession as EngineDebugSession,
   type MachineState as EngineMachineState,
   Reference,
   State,
@@ -9,6 +10,7 @@ import {
   ifOtherSymbol,
   haltState,
 } from '@turing-machine-js/machine';
+import { PostDebugSession } from './PostDebugSession';
 import {
   blankSymbol as defaultBlankSymbol,
   commandsSet,
@@ -101,74 +103,37 @@ export class PostMachine extends TuringMachine {
     this.tapeBlock.replaceTape(newTape);
   }
 
-  override async run({
-    stepsLimit = 1e5,
-    onStep,
-    onPause,
-    onIter,
-  }: {
-    stepsLimit?: number;
-    onStep?: (machineState: MachineState) => void;
-    onPause?: (machineState: MachineState) => void | Promise<void>;
-    onIter?: (machineState: MachineState) => void | Promise<void>;
-  } = {}): Promise<void> {
-    let prevState: State | null = null;
-    let prevJsSymbol: symbol | null = null;
-    const entryPath = this.#firstStepArrivalPath();
-
-    // Advance at end-of-iter (via the internal onIter wrapper) so both
-    // `onPause(before, K)` and `onPause(after, K)` read iter-correct prev.
-    // Advancing inside onStep would race after-fire arrivalPath resolution.
-    const advanceTracking = (raw: EngineMachineState): void => {
-      prevState = raw.state;
-      prevJsSymbol = this.tapeBlock.symbol([raw.currentSymbols[0]]);
-    };
-
-    // If the user provided any callback, our internal onIter wrapper must
-    // be registered to keep `prev` advancing — every callback (including the
-    // user's own onStep/onPause/onIter) receives the wrapped state which
-    // depends on prev. If no user callback is provided, no one observes
-    // wrapped state and we can skip the internal wrapper too, leaving the
-    // run to halt with zero per-iter await overhead.
-    const isAnyCallbackProvided = !!(onStep || onPause || onIter);
-
-    return super.run({
-      initialState: this.#initialState,
-      stepsLimit,
-      onStep: onStep ? (raw) => {
-        const wrapped = this.#wrapMachineState(raw, prevState, prevJsSymbol, entryPath);
-        onStep(wrapped);
-      } : undefined,
-      onPause: onPause ? async (raw) => {
-        const wrapped = this.#wrapMachineState(raw, prevState, prevJsSymbol, entryPath);
-        if (this.#shouldFireOnPause(raw, wrapped)) {
-          await onPause(wrapped);
-        }
-      } : undefined,
-      onIter: isAnyCallbackProvided ? async (raw) => {
-        if (onIter) {
-          // Wrap with PRE-advance prev so the user's onIter sees the same
-          // arrivalPath as onPause(after, K) saw — both describing the
-          // arrival at iter K.
-          const wrapped = this.#wrapMachineState(raw, prevState, prevJsSymbol, entryPath);
-          await onIter(wrapped);
-        }
-        advanceTracking(raw);
-      } : undefined,
-    });
+  /**
+   * Run the machine to halt — pure execution, no observation. Sync, returns
+   * void. Matches the engine's v7 `run()` contract.
+   *
+   * For interactive debugging (breakpoints, step-in / step-over / step-out,
+   * throttle, click-pause), use `debugRun()` to construct a `PostDebugSession`.
+   */
+  override run({ stepsLimit = 1e5 }: { stepsLimit?: number } = {}): void {
+    super.run({ initialState: this.#initialState, stepsLimit });
   }
 
-  #shouldFireOnPause(raw: EngineMachineState, wrapped: MachineState): boolean {
-    // Halt-arrival: engine pauses on the iteration whose nextState is halt,
-    // when haltState.debug is set. Yielded raw.state is the *previous* user
-    // instruction (e.g., 30 in `30: mark; 40: stop`), never haltState itself.
-    const nextIsHalt = raw.nextState instanceof State && raw.nextState.isHalt;
-    if (nextIsHalt && this.#breakpoints.some((bp) => bp.kind === 'halt')) {
-      return true;
-    }
-    const arrivalKey = formatPath(wrapped.arrivalPath);
-    return this.#breakpoints.some((bp) =>
-      bp.kind === 'instruction' && formatPath(bp.path) === arrivalKey);
+  /**
+   * Return a `PostDebugSession` bound to this PostMachine. The session
+   * wraps each engine MachineState with post-specific `arrivalPath` /
+   * `candidatePaths`, and applies the PostMachine's breakpoint registry as
+   * a filter before forwarding pause events.
+   */
+  debugRun({ stepsLimit = 1e5 }: { stepsLimit?: number } = {}): PostDebugSession {
+    const entryPath = this.#firstStepArrivalPath();
+    const engineSession = new EngineDebugSession(this, {
+      initialState: this.#initialState,
+      stepsLimit,
+    });
+    return new PostDebugSession({
+      postMachine: this,
+      engineSession,
+      entryPath,
+      wrap: (raw, prev, prevSym) => this.#wrapMachineState(raw, prev, prevSym, entryPath),
+      getBreakpoints: () => this.#breakpoints,
+      tapeBlockSymbol: (pattern) => this.tapeBlock.symbol(pattern),
+    });
   }
 
   override * runStepByStep({ stepsLimit = 1e5 }: { stepsLimit?: number } = {}): Generator<MachineState> {


### PR DESCRIPTION
Adopts engine **v7.0.0-alpha.6** ([turing-machine-js#102](https://github.com/mellonis/turing-machine-js/issues/102)) — the debug-surface reshape into `run()` (sync, pure) / `runStepByStep` (pure iteration) / `DebugSession` (interactive).

Closes #97.

## What changes

- **`PostMachine.run()` is sync + callback-free** — mirrors the engine's `run()` change (`Promise<void>` → `void`). Callbacks no longer live on `run`.
- **New `PostMachine.debugRun()` → `PostDebugSession`** — wraps the engine `DebugSession`, re-adds the Post-level `arrivalPath` / `candidatePaths`, applies the per-instruction breakpoint registry as a pause filter, and reads the engine's one-sided `m.pause: { side, cause }`.
- **`m.debugBreak` → `m.pause`** — adopts the engine's `PauseInfo { side: 'before' | 'after', cause: 'breakpoint' | 'step' | 'manual' }`; the per-yield `debugBreak` descriptor is gone.
- **`#wrapMachineState` now mutates in place** instead of spreading `{ ...raw }` — the engine's non-enumerable `MACHINE_STATE_INTERNAL` accessor (used for breakpoint detection) must survive the Post-level wrap, and a spread would drop it.
- **Lockfile refreshed** to pin engine `7.0.0-alpha.6` (was `alpha.5`, pre-`DebugSession`) so `npm ci` on `v7` resolves the API the code requires. `^7.0.0-alpha.5` already accepts alpha.6 by the semver-prerelease rule, so no manifest range change.

## Scope notes

- Targets **`v7`** (post's integration branch), not master. `closes #97` won't auto-fire on a `v7` merge — close manually after merge per the v7 workflow.
- **No peer-dep widen here** — engine-range widening (`^7.0.0-alpha.5` → `^7.0.0-alpha.6`) is deferred to the next post **alpha-release** bump branch, per the v7 release checklist. This is an adoption feature PR, not a release.

## Verification

- `npm run build` / `npm run lint` / `npm run typecheck` clean.
- `npm test` — **315 passed** (15 files), against linked engine alpha.6.
- Note: post's `main.yml` test CI triggers only on `pull_request: branches: [master]`, so this `v7`-targeted PR gets no test CI — the local run is the correctness gate.