### PR TITLE
chore(release): 7.0.0-alpha.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ machine.replaceTapeWith(new Tape({
 
 console.log(machine.tape.symbols.join('').trim()); // ***   *
 
-await machine.run();
+machine.run();
 
 console.log(machine.tape.symbols.join('').trim()); // ****
 ```
@@ -101,7 +101,7 @@ machine.replaceTapeWith(new Tape({
 
 console.log(machine.tape.symbols.join('').trim()); // *
 
-await machine.run();
+machine.run();
 
 console.log(machine.tape.symbols.join('').trim()); // **
 
@@ -114,7 +114,7 @@ machine.replaceTapeWith(new Tape({
 
 console.log(machine.tape.symbols.join('').trim()); // ***
 
-await machine.run();
+machine.run();
 
 console.log(machine.tape.symbols.join('').trim()); // ******
 ```

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.0.0-alpha.5",
+  "version": "7.0.0-alpha.6",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10441,16 +10441,16 @@
     },
     "packages/machine": {
       "name": "@post-machine-js/machine",
-      "version": "7.0.0-alpha.5",
+      "version": "7.0.0-alpha.6",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.5"
+        "@turing-machine-js/machine": "^7.0.0-alpha.6"
       },
       "engines": {
         "npm": ">=7.0.0"
       },
       "peerDependencies": {
-        "@turing-machine-js/machine": "^7.0.0-alpha.5"
+        "@turing-machine-js/machine": "^7.0.0-alpha.6"
       }
     }
   }

--- a/packages/machine/CHANGELOG.md
+++ b/packages/machine/CHANGELOG.md
@@ -4,6 +4,51 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.0-alpha.6] - 2026-05-29
+
+Adopts engine **v7.0.0-alpha.6** ([turing-machine-js#102](https://github.com/mellonis/turing-machine-js/issues/102)) — the debug-surface reshape. `PostMachine.run()` becomes synchronous and callback-free, a new `PostMachine.debugRun()` returns an interactive `PostDebugSession`, and the per-yield `m.debugBreak` is replaced by the engine's one-sided `m.pause: { side, cause }`. Published under the `next` dist-tag: `npm install @post-machine-js/machine@next`.
+
+> **Post alpha numbering is independent from the engine.** This `alpha.6` happens to match the engine `alpha.6` it adopts, but the two cycles are not lockstep — this is the second number coincidence after `alpha.5` (2026-05-25). Don't infer a lockstep relationship from the matching numbers.
+
+**Pre-release — the API surface may still shift before stable v7.0.0.** Pin to a specific alpha for reproducibility: `@post-machine-js/machine@7.0.0-alpha.6`.
+
+### Added
+
+- **`PostMachine.debugRun({ stepsLimit? })` → `PostDebugSession`** — the interactive debugger surface. Wraps the engine's `DebugSession`, re-adds the post-level `MachineState` fields (`arrivalPath` / `candidatePaths`), and applies the per-instruction breakpoint registry as a pause filter. Emits `pause` / `step` / `iter` / `halt` events (`session.on(event, listener)`); drive with `continue()` / `stepIn()` / `stepOver()` / `stepOut()` / `pause()` / `stop()` / `setRunInterval(ms)`; call `await session.start()` to begin.
+- **`PostPausedMachineState`** — `MachineState & { pause: PauseInfo }`, the `pause`-event payload. `PauseInfo = { side: 'before' | 'after', cause: 'breakpoint' | 'step' | 'manual' }` (re-exported transitively from the engine).
+
+### Changed
+
+- **`PostMachine.run()` is synchronous and callback-free** — `run({ stepsLimit? }): void` (was `async … : Promise<void>` accepting `onStep` / `onPause`). Mirrors the engine's `run()` change. **Breaking** for callers awaiting `run()` or passing callbacks — move per-step observation to `runStepByStep()` and breakpoints / stepping to `debugRun()`.
+
+  ```js
+  // before (alpha.5):
+  await pm.run({ onPause: (m) => { /* m.debugBreak */ } });
+
+  // alpha.6:
+  const session = pm.debugRun();
+  session.on('pause', (m) => { /* m.pause: { side, cause } */ session.continue(); });
+  await session.start();
+  ```
+
+- **`runStepByStep()` is the pure-iteration observation path** — unchanged in shape (`Generator<MachineState>`), but it's now where you read `arrivalPath` / `candidatePaths` per step (the role the removed `onStep` callback played).
+
+  ```js
+  for (const m of pm.runStepByStep()) {
+    // m.arrivalPath, m.candidatePaths
+  }
+  ```
+
+- **Engine peer dependency widened** `^7.0.0-alpha.5` → `^7.0.0-alpha.6` — `debugRun()` requires the engine's `DebugSession`, new in engine alpha.6.
+
+### Removed
+
+- **`onStep` / `onPause` callbacks on `run()`** and the per-yield **`m.debugBreak`** descriptor — replaced by `debugRun()` events + `m.pause`. **Breaking from alpha.5.**
+
+### Docs
+
+- README: rewrote the `PostMachine` method table, MachineState-shape, and Breakpoints sections for the `run()` / `debugRun()` / `runStepByStep()` split; dropped the now-pointless `await` on the synchronous `run()` throughout the examples.
+
 ## [7.0.0-alpha.5] - 2026-05-25
 
 Fifth v7 pre-release. Drops the module-load haltState lockdown in lockstep with engine [#207](https://github.com/mellonis/turing-machine-js/issues/207) — the lockdown was funneling per-side `DebugConfig` writes through `withLockdownEscape`, but with engine alpha.5 collapsing `haltState.debug` to a `boolean`, there's nothing to mediate. Engine peer-dep widened `^7.0.0-alpha.4` → `^7.0.0-alpha.5`; consumers inherit per-iter `MachineState.matchedTransition` ([engine #205](https://github.com/mellonis/turing-machine-js/issues/205)) and the `GraphTransition.id` separator change (`-` → `.`, same issue) transparently. Published to npm under the `next` dist-tag: `npm install @post-machine-js/machine@next`.

--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -20,7 +20,7 @@ A Post machine — a 2-symbol Turing-machine variant with a numbered-instruction
 - [Naming convention](#naming-convention)
 - [Tags](#tags) — [`$tag` decorator](#inline-tag-decorator) · [Registry](#post-construction-registry) · [Auto-tag policy](#auto-tag-policy) · [Mermaid output](#mermaid-output)
 - [Introspection and equivalence](#introspection-and-equivalence) — [Visualization](#visualization--tomermaid--statetograph) · [Structural summary](#structural-summary--summarizepostmachine) · [Behavioral equivalence](#behavioral-equivalence--equivalentpostmachines)
-- [Debugging](#debugging)
+- [Breakpoints](#breakpoints)
 - [Links](#links)
 
 </details>
@@ -52,7 +52,7 @@ machine.replaceTapeWith(new Tape({
   symbols: ['*', '*', ' '],
 }));
 
-await machine.run();
+machine.run();
 console.log(machine.tape.symbols.join('').trim()); // ***
 ```
 
@@ -101,8 +101,9 @@ The runtime. Subclasses `TuringMachine` from `@turing-machine-js/machine`: the c
 **Constructor.** `new PostMachine(instructions, options?)` — `instructions` is the numbered-instruction map (with optional string-keyed subroutine groups); `options` is `{ blankSymbol?, markSymbol? }` (see [Custom symbols](#custom-symbols)).
 
 **Methods.**
-- `run({ stepsLimit?, onStep?, onPause? } = {})` → `Promise<void>`. Runs to halt or until `stepsLimit` (default `1e5`) is exhausted. `onStep(m: MachineState)` fires once per applied transition; `onPause` forwards to the engine's debugger (see [Debugging](#debugging)).
-- `runStepByStep({ stepsLimit? } = {})` → `Generator<MachineState>`. Synchronous step-at-a-time execution; the consumer drives the loop with `for ... of` or `.next()`.
+- `run({ stepsLimit? } = {})` → `void`. Runs to halt or until `stepsLimit` (default `1e5`) is exhausted. **Synchronous and callback-free as of v7.0.0-alpha.6** (adopting engine [#102](https://github.com/mellonis/turing-machine-js/issues/102)) — for per-step observation use `runStepByStep()`; for breakpoints, throttling, or interactive stepping use `debugRun()`.
+- `debugRun({ stepsLimit? } = {})` → `PostDebugSession`. An interactive debugger session bound to this machine (see [Breakpoints](#breakpoints)). It emits `pause` / `step` / `iter` / `halt` events (`session.on(event, listener)`) and exposes `continue()` / `stepIn()` / `stepOver()` / `stepOut()` / `pause()` / `stop()` / `setRunInterval(ms)`; call `await session.start()` to begin. `pause`-event payloads carry `m.pause: { side: 'before' | 'after', cause: 'breakpoint' | 'step' | 'manual' }`.
+- `runStepByStep({ stepsLimit? } = {})` → `Generator<MachineState>`. Synchronous step-at-a-time execution; the consumer drives the loop with `for ... of` or `.next()`. Pure iteration — it does no breakpoint detection (that lives in `debugRun()`).
 - `replaceTapeWith(newTape)` — swap the active tape. Build the new tape against `machine.tape.alphabet` so symbol identities match the machine's interned alphabet.
 
 **Properties.**
@@ -146,7 +147,7 @@ machine.replaceTapeWith(new Tape({
   symbols: ['#', '#', '.'],
 }));
 
-await machine.run();
+machine.run();
 console.log(machine.tape.symbols.join('').replace(/\.+$/, '')); // ###
 ```
 
@@ -281,7 +282,7 @@ machine.replaceTapeWith(new Tape({
   position: 0,
 }));
 
-await machine.run();
+machine.run();
 console.log(machine.tape.symbols.join('').trim()); // **
 ```
 
@@ -314,7 +315,7 @@ machine.replaceTapeWith(new Tape({
   symbols: ['*', '*', ' '],
 }));
 
-await machine.run();
+machine.run();
 console.log(machine.tape.symbols.join('').trim()); // ***
 ```
 
@@ -388,7 +389,7 @@ extend.replaceTapeWith(new Tape({
   position: 1,
 }));
 
-await extend.run();
+extend.run();
 console.log(extend.tape.symbols.join('')); // ***
 ```
 
@@ -398,7 +399,7 @@ For a single subroutine called from MULTIPLE sites — the other archetypal use 
 
 ## MachineState shape
 
-PostMachine's `onStep` and `onPause` callbacks receive an extended `MachineState` with two additional fields:
+Every `MachineState` PostMachine yields — from `runStepByStep()` and from `debugRun()` session events (`step` / `iter` / `pause`) — is an extended `MachineState` with two additional fields:
 
 | Field             | Type     | Meaning                                                                                  |
 |-------------------|----------|------------------------------------------------------------------------------------------|
@@ -417,11 +418,9 @@ const m = new PostMachine({
   20: stop,
 });
 
-await m.run({
-  onStep: (s) => {
-    console.log('at:', s.arrivalPath, 'shared with:', s.candidatePaths);
-  },
-});
+for (const s of m.runStepByStep()) {
+  console.log('at:', s.arrivalPath, 'shared with:', s.candidatePaths);
+}
 ```
 
 The `Path` type and the `parsePath`/`formatPath` helpers are exported from `@post-machine-js/machine` — see the [Naming convention](#naming-convention) section for the path-string format.
@@ -477,7 +476,7 @@ const m = new PostMachine({
 
 PostMachine caches state nodes by command shape, so two instructions producing structurally-identical transitions (same command kind, same next-instruction target) share a single underlying `State` object. The shared state carries the name of the *first-processed* instruction. Behavior is identical regardless of which instruction control arrives through, but `MachineState.name` may report the canonical instruction's name rather than the caller's instruction index.
 
-For programmatic lookup by instruction index, use `pm.candidatesFor(path)` (construction-time) or read `MachineState.candidatePaths` from an `onStep` / `onPause` callback (runtime). See [Path-based resolver](#path-based-resolver) and [MachineState shape](#machinestate-shape).
+For programmatic lookup by instruction index, use `pm.candidatesFor(path)` (construction-time) or read `MachineState.candidatePaths` from a `runStepByStep()` yield or a `debugRun()` session event (runtime). See [Path-based resolver](#path-based-resolver) and [MachineState shape](#machinestate-shape).
 
 ### Engine v7 alignment
 
@@ -861,11 +860,13 @@ pm.replaceTapeWith(new Tape({ alphabet: pm.tape.alphabet, symbols: ['*', '*', ' 
 
 pm.setBreakpoint('30', { before: true });
 
-await pm.run({
-  onPause: (m) => {
-    // m.arrivalPath === { instructionIndex: 30 }
-  },
+const session = pm.debugRun();
+session.on('pause', (m) => {
+  // m.arrivalPath === { instructionIndex: 30 }
+  // m.pause === { side: 'before', cause: 'breakpoint' }
+  session.continue();
 });
+await session.start();
 ```
 
 Filters mirror the engine's `DebugConfig`:
@@ -883,7 +884,7 @@ Halt breakpoints:
 pm.setBreakpoint(haltState, { before: true });       // pause at halt entry (filter shape is decorative)
 ```
 
-> Engine [#207](https://github.com/mellonis/turing-machine-js/issues/207) collapsed `haltState.debug` to a `boolean` — halt has one meaningful pause moment. The `filter` shape passed to `pm.setBreakpoint(haltState, …)` is kept for API stability but is now decorative: any registered halt breakpoint enables the engine-level boolean, and the registry entry drives only the arrival-path filtering in PostMachine's `onPause` wrapper. The pause fires on the AFTER side of the iter whose transition leads to halt.
+> Engine [#207](https://github.com/mellonis/turing-machine-js/issues/207) collapsed `haltState.debug` to a `boolean` — halt has one meaningful pause moment. The `filter` shape passed to `pm.setBreakpoint(haltState, …)` is kept for API stability but is now decorative: any registered halt breakpoint enables the engine-level boolean, and the registry entry drives only the arrival-path filtering in the `debugRun()` session's pause filter. The pause fires on the AFTER side of the iter whose transition leads to halt.
 
 Management:
 
@@ -893,7 +894,7 @@ pm.clearBreakpoint('10');  // remove a single registration
 pm.clearBreakpoints();     // remove all
 ```
 
-**State sharing.** When two instructions share an underlying State (hash dedup), setting a breakpoint on instruction 30 enables `state.debug` on the shared State — meaning the engine pauses on every visit. PostMachine's `onPause` wrapper consults the registry and *only* surfaces the pause when `m.arrivalPath` matches a registered path. Sibling-instruction visits silently resume.
+**State sharing.** When two instructions share an underlying State (hash dedup), setting a breakpoint on instruction 30 enables `state.debug` on the shared State — meaning the engine pauses on every visit. The `debugRun()` session consults the registry and *only* surfaces the pause when `m.arrivalPath` matches a registered path. Sibling-instruction visits auto-continue.
 
 ### Lockdown semantics
 
@@ -920,7 +921,7 @@ haltState.debug = { before: true };                  // throws: "haltState.debug
 
 Direct halt writes bypass PostMachine's registry — they enable the engine pause but `pm.listBreakpoints()` won't record them. Use `pm.setBreakpoint(haltState, …)` when arrival-path filtering or registry awareness matters; use the direct write for ad-hoc halt-pause toggling in tools that don't need the registry.
 
-This relaxed model preserves the single-channel invariant where it matters: `pm.listBreakpoints()` is still the source of truth for what PostMachine's `onPause` wrapper surfaces. The engine's pause itself is now an open channel — by design, since the halt-lockdown's "per-PostMachine routing" benefit was syntactic only (haltState is a process-global singleton).
+This relaxed model preserves the single-channel invariant where it matters: `pm.listBreakpoints()` is still the source of truth for what the `debugRun()` session surfaces. The engine's pause itself is now an open channel — by design, since the halt-lockdown's "per-PostMachine routing" benefit was syntactic only (haltState is a process-global singleton).
 
 For the underlying engine reference — filter shapes for non-halt states, the `before → step → after` per-iter lifecycle (engine v6), and the boolean `haltState.debug` API (engine #207) — see [Debugging breakpoints](https://github.com/mellonis/turing-machine-js/tree/master/packages/machine#debugging-breakpoints) in the upstream README.
 

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@post-machine-js/machine",
-  "version": "7.0.0-alpha.5",
+  "version": "7.0.0-alpha.6",
   "description": "A convenient Post machine",
   "engines": {
     "npm": ">=7.0.0"
@@ -28,10 +28,10 @@
     "machine"
   ],
   "peerDependencies": {
-    "@turing-machine-js/machine": "^7.0.0-alpha.5"
+    "@turing-machine-js/machine": "^7.0.0-alpha.6"
   },
   "devDependencies": {
-    "@turing-machine-js/machine": "^7.0.0-alpha.5"
+    "@turing-machine-js/machine": "^7.0.0-alpha.6"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/machine/src/classes/PostMachine.custom-alphabet.spec.ts
+++ b/packages/machine/src/classes/PostMachine.custom-alphabet.spec.ts
@@ -82,7 +82,7 @@ describe('PostMachine custom alphabet', () => {
         symbols: ['.'],
       }));
 
-      await machine.run();
+      machine.run();
 
       expect(machine.tape.symbols.join('')).toBe('#');
     });
@@ -98,7 +98,7 @@ describe('PostMachine custom alphabet', () => {
         symbols: ['#'],
       }));
 
-      await machine.run();
+      machine.run();
 
       expect(machine.tape.symbols.join('')).toBe('.');
     });
@@ -121,7 +121,7 @@ describe('PostMachine custom alphabet', () => {
         symbols: ['#', '#', '.'],
       }));
 
-      await machine.run();
+      machine.run();
 
       expect(machine.tape.symbols.join('').replace(/\.+$/, '')).toBe('###');
     });
@@ -141,7 +141,7 @@ describe('PostMachine custom alphabet', () => {
         position: 0,
       }));
 
-      await machine.run();
+      machine.run();
 
       // head moved right by one; tape contents unchanged
       expect(machine.tape.symbols.join('')).toBe('#.#');
@@ -167,7 +167,7 @@ describe('PostMachine custom alphabet', () => {
         symbols: ['#', '#', '.'],
       }));
 
-      await machine.run();
+      machine.run();
 
       expect(machine.tape.symbols.join('').replace(/\.+$/, '')).toBe('###');
     });
@@ -187,7 +187,7 @@ describe('PostMachine custom alphabet', () => {
         symbols: ['.', '.'],
       }));
 
-      await machine.run();
+      machine.run();
 
       expect(machine.tape.symbols.join('')).toBe('#.');
     });
@@ -225,7 +225,7 @@ describe('PostMachine custom alphabet', () => {
         symbols: ['•', '•', '␣'],
       }));
 
-      await machine.run();
+      machine.run();
 
       expect(machine.tape.symbols.join('').replace(/␣+$/, '')).toBe('•••');
     });
@@ -244,7 +244,7 @@ describe('PostMachine custom alphabet', () => {
         position: 1,
       }));
 
-      await machine.run();
+      machine.run();
 
       // After one left move, head sits at position 0; symbols unchanged.
       expect(machine.tape.symbols.join('')).toBe('##');

--- a/packages/machine/src/classes/PostMachine.debugger.spec.ts
+++ b/packages/machine/src/classes/PostMachine.debugger.spec.ts
@@ -5,7 +5,8 @@
 import {
   PostMachine,
   Tape,
-  check, mark, right, stop,
+  haltState,
+  call, check, mark, right, stop,
 } from '../index';
 
 describe('PostMachine — async run', () => {
@@ -118,5 +119,144 @@ describe('PostMachine — onPause forwarding', () => {
 
     // If start() resolved before the async callback finished, this would be false.
     expect(asyncCallbackResolved).toBe(true);
+  });
+});
+
+describe('PostDebugSession — step controls and lifecycle', () => {
+  test('stepIn() forces a step-cause pause on the next instruction', async () => {
+    const machine = new PostMachine({ 10: mark, 20: mark, 30: stop });
+    machine.setBreakpoint('10', { before: true });
+
+    const causes: string[] = [];
+    const session = machine.debugRun();
+    let first = true;
+    session.on('pause', (m) => {
+      causes.push(m.pause.cause);
+      if (first) { first = false; session.stepIn(); } else { session.continue(); }
+    });
+    await session.start();
+
+    expect(causes[0]).toBe('breakpoint');
+    expect(causes[1]).toBe('step');
+  });
+
+  test('stepOver() runs a called subroutine to completion, then pauses (cause: step)', async () => {
+    const machine = new PostMachine({
+      10: call('foo'),
+      20: mark,
+      30: stop,
+      foo: { 1: mark, 2: stop },
+    });
+    machine.setBreakpoint('10', { before: true });
+
+    const causes: string[] = [];
+    const session = machine.debugRun();
+    let first = true;
+    session.on('pause', (m) => {
+      causes.push(m.pause.cause);
+      if (first) { first = false; session.stepOver(); } else { session.continue(); }
+    });
+    await session.start();
+
+    expect(causes[0]).toBe('breakpoint');
+    expect(causes).toContain('step');
+  });
+
+  test('stepOut() from inside a subroutine pops the frame back to the caller level', async () => {
+    const machine = new PostMachine({
+      10: call('foo'),
+      20: mark,
+      30: stop,
+      foo: { 1: mark, 2: mark, 3: stop },
+    });
+    machine.setBreakpoint('10', { before: true });
+
+    const causes: string[] = [];
+    let phase = 0;
+    const session = machine.debugRun();
+    session.on('pause', (m) => {
+      causes.push(m.pause.cause);
+      if (phase === 0) { phase = 1; session.stepIn(); }        // descend into foo (depth >= 1)
+      else if (phase === 1) { phase = 2; session.stepOut(); }  // pop foo's frame back to the caller
+      else { session.continue(); }
+    });
+    await session.start();
+
+    expect(causes[0]).toBe('breakpoint');
+    expect(causes.length).toBeGreaterThanOrEqual(2);
+    expect(causes.slice(1)).toContain('step');
+  });
+
+  test('external pause() fires a manual-cause pause; setRunInterval throttles the run', async () => {
+    const machine = new PostMachine({ 10: mark, 20: mark, 30: mark, 40: stop });
+    const session = machine.debugRun();
+    session.setRunInterval(2);  // slow enough to request a pause mid-run
+
+    let requested = false;
+    const causes: string[] = [];
+    session.on('iter', (m) => {
+      if (m.step === 1 && !requested) { requested = true; session.pause(); }
+    });
+    session.on('pause', (m) => {
+      causes.push(m.pause.cause);
+      session.continue();
+    });
+    await session.start();
+
+    expect(causes).toEqual(['manual']);
+  });
+
+  test('stop() from an iter listener terminates without firing halt', async () => {
+    const machine = new PostMachine({ 10: mark, 20: mark, 30: mark, 40: stop });
+    const session = machine.debugRun();
+
+    let haltFired = false;
+    let stopped = false;
+    session.on('halt', () => { haltFired = true; });
+    session.on('iter', () => { if (!stopped) { stopped = true; session.stop(); } });
+    await session.start();
+
+    expect(haltFired).toBe(false);
+  });
+
+  test('off() removes a previously registered listener (and is a no-op for an unregistered one)', async () => {
+    const machine = new PostMachine({ 10: mark, 20: stop });
+    const session = machine.debugRun();
+
+    let called = false;
+    const handler = () => { called = true; };
+    session.on('halt', handler);
+    session.off('halt', handler);
+    // Removing a listener that was never registered is a no-op, not an error.
+    session.off('halt', () => { /* never registered */ });
+    await session.start();
+
+    expect(called).toBe(false);
+  });
+
+  test('a halt breakpoint surfaces a breakpoint-cause pause', async () => {
+    const machine = new PostMachine({ 10: mark, 20: stop });
+    machine.setBreakpoint(haltState, { before: true });
+
+    const causes: string[] = [];
+    const session = machine.debugRun();
+    session.on('pause', (m) => { causes.push(m.pause.cause); session.continue(); });
+    await session.start();
+
+    expect(causes).toContain('breakpoint');
+  });
+
+  test('step and halt listeners fire during an uninterrupted run', async () => {
+    const machine = new PostMachine({ 10: mark, 20: stop });
+    const session = machine.debugRun();
+
+    let steps = 0;
+    let halted = false;
+    session.on('step', () => { steps += 1; });
+    session.on('halt', () => { halted = true; });
+    await session.start();
+
+    expect(steps).toBeGreaterThan(0);
+    expect(halted).toBe(true);
   });
 });

--- a/packages/machine/src/classes/PostMachine.examples.spec.ts
+++ b/packages/machine/src/classes/PostMachine.examples.spec.ts
@@ -53,7 +53,7 @@ describe('packages/machine/README.md', () => {
         symbols: ['*', '*', ' '],
       }));
 
-      await machine.run();
+      machine.run();
 
       // console.log(machine.tape.symbols.join('').trim()); // ***
       expect(machine.tape.symbols.join('').trim())
@@ -149,7 +149,7 @@ describe('packages/machine/README.md', () => {
         position: 0,
       }));
 
-      await machine.run();
+      machine.run();
 
       // console.log(machine.tape.symbols.join('').trim()); // **
       expect(machine.tape.symbols.join('').trim())
@@ -267,7 +267,7 @@ describe('packages/machine/README.md', () => {
         symbols: ['*', '*', ' '],
       }));
 
-      await machine.run();
+      machine.run();
 
       // console.log(machine.tape.symbols.join('').trim()); // ***
       expect(machine.tape.symbols.join('').trim())
@@ -299,7 +299,7 @@ describe('packages/machine/README.md', () => {
         position: 1,
       }));
 
-      await extend.run();
+      extend.run();
 
       // console.log(extend.tape.symbols.join('')); // ***
       expect(extend.tape.symbols.join(''))
@@ -324,7 +324,7 @@ describe('packages/machine/README.md', () => {
         symbols: ['#', '#', '.'],
       }));
 
-      await machine.run();
+      machine.run();
 
       // console.log(machine.tape.symbols.join('').replace(/\.+$/, '')); // ###
       expect(machine.tape.symbols.join('').replace(/\.+$/, ''))

--- a/packages/machine/src/commands.spec.ts
+++ b/packages/machine/src/commands.spec.ts
@@ -144,7 +144,7 @@ describe('$tag — inline tag decorator (#86)', () => {
     });
 
     // The tag doesn't affect runtime — the machine still halts normally.
-    await machine.run();
+    machine.run();
 
     expect(machine.tape.symbols[0]).toBe('*');
   });

--- a/test/examples.spec.ts
+++ b/test/examples.spec.ts
@@ -31,7 +31,7 @@ describe('README.md', () => {
       expect(machine.tape.symbols.join('').trim())
         .toBe('***   *');
 
-      await machine.run();
+      machine.run();
 
       expect(machine.tape.symbols.join('').trim())
         .toBe('****');
@@ -77,7 +77,7 @@ describe('README.md', () => {
       expect(machine.tape.symbols.join('').trim())
         .toBe('*');
 
-      await machine.run();
+      machine.run();
 
       expect(machine.tape.symbols.join('').trim())
         .toBe('**');
@@ -92,7 +92,7 @@ describe('README.md', () => {
       expect(machine.tape.symbols.join('').trim())
         .toBe('***');
 
-      await machine.run();
+      machine.run();
 
       expect(machine.tape.symbols.join('').trim())
         .toBe('******');


### PR DESCRIPTION
Sixth v7 pre-release of `@post-machine-js/machine`. Ships the engine **v7.0.0-alpha.6** ([#102](https://github.com/mellonis/turing-machine-js/issues/102)) `DebugSession` adoption (merged to `v7` via #100) as a published alpha, with the deferred peer-dep widen and the README brought in line with the new API.

> **Post alpha numbering is independent from the engine.** This `alpha.6` matches the engine `alpha.6` it adopts, but the cycles are not lockstep — second number coincidence after `alpha.5`.

## What ships

- **`PostMachine.run()` → sync + callback-free**; new **`PostMachine.debugRun()` → `PostDebugSession`** (interactive `pause`/`step`/`iter`/`halt` events + `continue`/`stepIn`/`stepOver`/`stepOut`/`pause`/`stop`/`setRunInterval`); per-yield `m.debugBreak` → one-sided `m.pause: { side, cause }`. **Breaking from alpha.5.**
- **Engine peer + dev dep widened** `^7.0.0-alpha.5` → `^7.0.0-alpha.6` (`debugRun()` needs the engine's `DebugSession`); lockfile resynced.

## Release contents

- Bumped `lerna.json` + `packages/machine/package.json` to `7.0.0-alpha.6` (root `package.json` decoupled, untouched).
- CHANGELOG entry (Added / Changed / Removed + migration blocks + independent-numbering note).
- **README rewrite** — the method table, MachineState-shape, and Breakpoints sections now document the `run()` / `debugRun()` / `runStepByStep()` split (the adoption #100 had migrated source + tests but not the README, which ships in the tarball). Also dropped the now-pointless `await` on the synchronous `run()` across both READMEs and the specs, and fixed a dangling ToC anchor.

## Follow-up

- #101 — Post-level `stepInstruction()` (step to next instruction index, skipping group sub-steps). Not required for this release.

## Verification

- `npm run build` / `npm run lint` / `npm run typecheck` clean; `npm test` — **315 passed** (15 files).
- `npm publish --dry-run --workspaces --tag next` → `7.0.0-alpha.6`, tag `next`.
- Note: post's `main.yml` test CI runs only on `pull_request: branches: [master]`, so this `v7`-targeted PR gets no test CI — the local run is the gate.

## Publish (after merge)

Publishes under the **`next`** dist-tag (npm `latest` stays `6.4.0`):

```
npx lerna publish from-package --dist-tag next --yes
```