### PR TITLE
docs(machine): hedge wrapper-placement prose for framed wrappers

### DIFF
--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -83,7 +83,7 @@ Reading the diagram:
 - `(((label)))` — halt state
 - `["label"]` — intermediate (and now also entry) state
 - `([idle])` — the `idle` sentinel that marks the entry point via a dotted `idle -. enter .-> s_initial` edge
-- (Wrappers produced by `withOverriddenHaltState` use a `[[bare(continuation)]]` double-square node sitting OUTSIDE its callable subtree's `subgraph w_N["callable subtree of NAME"]` block — see the [Subroutines](#subroutines) section.)
+- (Wrappers produced by `withOverriddenHaltState` use a `[[bare(continuation)]]` double-square node. Top-level wrappers sit OUTSIDE their callable subtree's `subgraph w_N["callable subtree of NAME"]` block; wrappers whose continuation chain participates in a caller's frame render INSIDE the owner frame's subgraph with the same `[[…]]` shape — see the [Subroutines](#subroutines) section.)
 
 The labels are PostMachine's instruction-derived names — `"10"`, `"20"`, `"30"` map directly to the instruction indices in the program. The wrapper composite shape (`"<outer>(<continuation>)"`) doesn't appear in this example because there are no calls or groups; see the [Subroutines](#subroutines) section for that. The `40: stop` instruction is elided — `stop` halts the machine, so the transition from `30: mark` flows straight to halt rather than through an intermediate state.
 


### PR DESCRIPTION
## Summary
- The README's node-shapes bullet (line 86) claimed `withOverriddenHaltState` wrappers always sit OUTSIDE their callable subtree's `subgraph w_N` block. That was true of v7 output up to alpha.6, but the engine fix in turing-machine-js [#223](https://github.com/mellonis/turing-machine-js/issues/223) / [PR #224](https://github.com/mellonis/turing-machine-js/pull/224) moves framed wrappers (continuation chain participates in a caller's frame) INSIDE the owner frame's subgraph with the same `[[…]]` shape.
- Splits the prose into top-level vs framed cases. No diagram regenerations needed in this README — all 10 mermaid blocks use top-level wrappers (`s7 = main`-tagged), and top-level wrappers still render outside.

## Test plan
- [x] Render-check post README mermaid blocks — unchanged (top-level wrappers stay outside)
- [ ] Reviewer skims line 86 wording to confirm it reads naturally