### PR TITLE
docs(machine/README): scope rules for indexed forms + call(name)

### DIFF
--- a/packages/machine/README.md
+++ b/packages/machine/README.md
@@ -13,7 +13,7 @@ A Post machine — a 2-symbol Turing-machine variant with a numbered-instruction
 - [Classes](#classes) — [`PostMachine`](#postmachine) · [`Tape`](#tape)
 - [Constants](#constants)
 - [Custom symbols](#custom-symbols)
-- [Commands](#commands) — [Classical](#classical-commands) · [Author's extensions](#authors-extensions)
+- [Commands](#commands) — [Classical](#classical-commands) · [Author's extensions](#authors-extensions) · [Scope rules](#scope-rules-for-indexed-forms)
 - [Grouped instructions](#grouped-instructions)
 - [Subroutines](#subroutines)
 - [MachineState shape](#machinestate-shape)
@@ -180,6 +180,22 @@ The first table is the **canonical instruction set** of a Post(–Turing) machin
 | `noop` | `noop` | `noop(ix)` | Do nothing; fall through / jump to `ix` |
 
 `call` and the [Subroutines](#subroutines) feature add procedure-like reuse to the classical numbered-instruction model. `noop` is the placeholder of choice: useful for reserving instruction numbers in a worked example, padding a sketch, or as a labelled jump target. (Bare `noop` has no classical analog; `noop(ix)` corresponds to Post's unconditional jump.)
+
+### Scope rules for indexed forms
+
+The `ix` in any indexed form (`mark(ix)`, `erase(ix)`, `noop(ix)`, `left(ix)`, `right(ix)`, `check(ix1, ix0)`, and `call(name, ix)`'s second arg) always references **the scope the call is written in** — top-level when at the top of the instructions map, the surrounding [subroutine](#subroutines)'s local indices when inside a subroutine body. The post engine resolves indexed jumps lexically; there is no implicit jump to top-level from inside a subroutine.
+
+`call(name)`'s `name` argument is resolved by walking the **lexical scope chain from the current scope outward**, first match wins. Subroutines can nest (a subroutine body may itself contain string-keyed subroutines), and `call('foo')` from inside `outer` finds `outer.foo` before checking the top-level program. This mirrors how identifiers resolve in lexically-scoped languages.
+
+| Construct | Scope of the literal arg |
+|---|---|
+| Top-level `mark(20)` | top-level instruction indices |
+| Inside `subA`: `mark(2)` | `subA`'s local indices |
+| Top-level `call('foo')` | searches top-level subroutines |
+| Inside `subA`: `call('foo')` | searches `subA`'s local subroutines first, then walks outward to top-level |
+| Inside `subA`: `call('foo', 5)` | second arg `5` is in `subA`'s local indices (where to jump after `foo` returns) |
+
+The [Subroutines](#subroutines) section shows nesting and call-site examples; the canonical path notation (`foo::bar::1`) reflects this lexical nesting directly.
 
 <details>
 <summary><code>noop</code> in the graph — fall-through and unconditional jump</summary>


### PR DESCRIPTION
## Summary

Two scope rules were implicit in the README before — shown by example in the [Subroutines](packages/machine/README.md#subroutines) section but never stated as rules. Making them explicit removes the kind of ambiguity that bites consumers and tooling.

### The rules being added

1. **The \`ix\` in any indexed form references the scope the call is written in.** Applies to \`mark(ix)\`, \`erase(ix)\`, \`noop(ix)\`, \`left(ix)\`, \`right(ix)\`, \`check(ix1, ix0)\`, and \`call(name, ix)\`'s second arg. Top-level when at top; subroutine-local when inside a subroutine body. No implicit jump to top-level from within a subroutine.

2. **\`call(name)\` resolves names by walking the lexical scope chain from the current scope outward, first match wins.** Subroutines can nest — a \`call('inner')\` from inside \`outer\` finds \`outer.inner\` before checking the top-level program. This mirrors identifier resolution in lexically-scoped languages, and matches the path notation (\`foo::bar::1\`) already documented at \"Naming convention\".

### Where it lives

A new \"Scope rules for indexed forms\" subsection right after the Author's extensions table in the Commands section, plus a TOC pointer. Placed BEFORE the Subroutines section so a reader encountering \`mark(20)\` / \`check(20, 40)\` examples knows what they mean. A short scope-of-the-literal-arg table covers the common cases without bloating the section.

## Why now

The rules surfaced during a [cross-reference linter for the demo](https://github.com/mellonis/machines-demo/pull/117) (the linter validates literal arg references against the surrounding \`new PostMachine({ … })\`). To get \`call(name, ix)\`'s scope right I had to ask twice; an initial \"subroutines are flat / always top-level\" reading was corrected to \"subroutines nest / lexical chain.\" Writing the rules down means the next person (or tool) gets them on the first read.

## Test plan

- [x] Prose only — no executable code examples added (the inline shapes like \`mark(ix)\` and the scope table are illustrative, not runnable). No \`examples.spec.ts\` change needed per the README→examples test convention.
- [x] \`npm run lint\` clean.
- [x] \`npm test\` — 332 / 332 specs still passing.